### PR TITLE
Seperate /imu and /audio on I2C

### DIFF
--- a/firmware/atom_echo_i2c_audio/atom_echo_i2c_audio.ino
+++ b/firmware/atom_echo_i2c_audio/atom_echo_i2c_audio.ino
@@ -16,7 +16,7 @@ constexpr int CONFIG_I2S_DATA_IN_PIN = 23;
 constexpr i2s_port_t SPEAK_I2S_NUMBER = I2S_NUM_0;
 constexpr int MODE_MIC = 0;
 constexpr int MODE_SPK = 1;
-constexpr int I2S_SAMPLE_RATE = 16000;
+constexpr int I2S_SAMPLE_RATE = 8000;
 constexpr int I2S_BUFFER_COUNT = 4;
 constexpr int I2S_BUFFER_SIZE = 1000;
 
@@ -154,8 +154,8 @@ void loop() {
 void requestEvent() {
     while (ringBuffer.available() > 0) {
         uint16_t value = ringBuffer.read();
+        value = value / 256;
         WireSlave.write((uint8_t)(value & 0xFF));
-        WireSlave.write((uint8_t)((value >> 8) & 0xFF));
     }
 }
 

--- a/ros/riberry_startup/launch/speech_recognition.launch
+++ b/ros/riberry_startup/launch/speech_recognition.launch
@@ -3,8 +3,8 @@
   <arg name="raw_audio_topic" default="/audio" doc="Name of audio topic captured from microphone" />
   <arg name="dummy_audio_topic" default="/dummy_audio" doc="Dummy audio" />
   <arg name="audio_topic" default="/audio" doc="Name of audio topic captured from microphone" />
-  <arg name="depth" default="16" doc="Bit depth of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
-  <arg name="sample_rate" default="16000" doc="Frame rate of audio topic and microphone. '$ pactl list short sinks' to check your hardware"/>
+  <arg name="depth" default="8" doc="Bit depth of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
+  <arg name="sample_rate" default="8000" doc="Frame rate of audio topic and microphone. '$ pactl list short sinks' to check your hardware"/>
   <arg name="device" default="bluealsa:DEV=64:B7:08:8A:14:16,PROFILE=a2dp" doc="Card and device number of microphone (e.g. hw:0,0). you can check card number and device number by '$ arecord -l', then uses hw:[card number],[device number]" />
   <arg name="n_channel" default="1" doc="Number of channels of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
   <arg name="sound_play_respawn" default="true" />

--- a/ros/riberry_startup/node_scripts/speak_to_light.py
+++ b/ros/riberry_startup/node_scripts/speak_to_light.py
@@ -13,7 +13,7 @@ from speech_recognition_msgs.msg import SpeechRecognitionCandidates
 if __name__ == '__main__':
     rospy.init_node('speak_to_light')
 
-    i2c = busio.I2C(board.SCL1, board.SDA1, frequency=1_000_000)
+    i2c = busio.I2C(board.SCL3, board.SDA3, frequency=1_000_000)
     i2c_addr = 0x41
     while not i2c.try_lock():
         pass

--- a/ros/riberry_startup/src/i2c_audio_publisher.cpp
+++ b/ros/riberry_startup/src/i2c_audio_publisher.cpp
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
   int buffer_size;
   int i2c_addr;
 
-  private_nh.param<std::string>("i2c_device", i2c_device, "/dev/i2c-1");
+  private_nh.param<std::string>("i2c_device", i2c_device, "/dev/i2c-3");
   private_nh.param("buffer_size", buffer_size, 4096);
   private_nh.param("i2c_addr", i2c_addr, 0x41);
 


### PR DESCRIPTION
I could not use both /imu(200Hz) and /audio(16000Hz, 16bit) even with I2C1 set to 1Mbps.

So I separated /audio and /imu bus.
In addition, radxa's i2c3 is only available up to 100 kbps, so the quality of the /audio was reduced. (16000Hz, 16bit -> 8000Hz, 8bit)

I checked that `ros_speech_recognition` works with this `/audio`.