### PR TITLE
Apply DC filter to remove DC offset and use 16bitdepth for audio

### DIFF
--- a/ros/riberry_startup/launch/speech_recognition.launch
+++ b/ros/riberry_startup/launch/speech_recognition.launch
@@ -3,7 +3,7 @@
   <arg name="raw_audio_topic" default="/audio" doc="Name of audio topic captured from microphone" />
   <arg name="dummy_audio_topic" default="/dummy_audio" doc="Dummy audio" />
   <arg name="audio_topic" default="/audio" doc="Name of audio topic captured from microphone" />
-  <arg name="depth" default="8" doc="Bit depth of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
+  <arg name="depth" default="16" doc="Bit depth of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />
   <arg name="sample_rate" default="8000" doc="Frame rate of audio topic and microphone. '$ pactl list short sinks' to check your hardware"/>
   <arg name="device" default="bluealsa:DEV=64:B7:08:8A:14:16,PROFILE=a2dp" doc="Card and device number of microphone (e.g. hw:0,0). you can check card number and device number by '$ arecord -l', then uses hw:[card number],[device number]" />
   <arg name="n_channel" default="1" doc="Number of channels of audio topic and microphone. '$ pactl list short sinks' to check your hardware" />


### PR DESCRIPTION
Update audio processing to support 16-bit depth and add conversion functionality

This PR updates the audio processing configuration and functionality within the Riberry startup ROS package to accommodate 16-bit audio depth, replacing the previous 8-bit setting. This change is prompted by compatibility issues encountered with many programs that expect 16-bit audio data, which can lead to problems in processing 8-bit audio correctly.

In the speech_recognition.launch file, the default bit depth for audio topics and the microphone is increased from 8 to 16 bits. This modification ensures that the audio data aligns with the common 16-bit standard expected by most audio processing tools and libraries, enhancing compatibility and potentially improving audio quality.

Additionally, a new function, `convertAndPack`, is introduced in the i2c_audio_publisher.cpp file. This function is designed to convert 8-bit audio data to 16-bit by shifting and packing the data into a higher bit depth format. The conversion process involves scaling the 8-bit signed byte data to 16-bit, ensuring that the audio signal is preserved and properly formatted for subsequent processing steps.

This adjustment addresses potential issues in audio signal handling and processing, making the system more robust and compatible with audio programs.