### PR TITLE
Pubish button state for atom s3

### DIFF
--- a/firmware/atom_s3_i2c_display/platformio.ini
+++ b/firmware/atom_s3_i2c_display/platformio.ini
@@ -8,3 +8,4 @@ lib_deps =
     m5stack/M5Unified @ 0.1.14
     Fastled/FastLED @ 3.6.0
     iory/i2c-for-esp32 @ 0.4.1
+    mathertel/OneButton

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -13,10 +13,6 @@ constexpr int I2C_SLAVE_ADDR = 0x42;
 unsigned long lastReceiveTime = 0;
 const unsigned long receiveTimeout = 15000;  // Timeout in milliseconds (15 seconds)
 
-Stream* target_serial;
-String target_serial_type = "i2c";  // For testing purposes, set to "i2c"
-// String target_serial_type = "serial1";
-
 void receiveEvent(int howMany);
 void requestEvent();
 

--- a/ros/riberry_startup/CMakeLists.txt
+++ b/ros/riberry_startup/CMakeLists.txt
@@ -44,6 +44,11 @@ target_link_libraries(i2c_audio_publisher
   ${catkin_LIBRARIES}
 )
 
+add_executable(i2c_button_state_publisher src/i2c_button_state_publisher.cpp)
+target_link_libraries(i2c_button_state_publisher
+  ${catkin_LIBRARIES}
+)
+
 add_executable(imu_filter src/imu_filter.cpp)
 target_link_libraries(imu_filter
   ${catkin_LIBRARIES}

--- a/ros/riberry_startup/README.md
+++ b/ros/riberry_startup/README.md
@@ -1,1 +1,28 @@
 # riberry startup
+
+## atoms3_button_state_publisher.launch
+
+The atom s3 display features a multi-functional button capable of detecting various press patterns, which are essential for implementing diverse interactive features. When the `atoms3_button_state_publisher.launch` is executed with the following command:
+
+```bash
+roslaunch riberry_startup atoms3_button_state_publisher.launch
+```
+
+It publishes the state of the button on the `/atom_s3_button_state` topic as an `std_msgs/Int32` value.
+Below is a table outlining these states, their descriptions, and corresponding numeric values:
+
+| Button State      | Description                                             | Numeric Value |
+|-------------------|---------------------------------------------------------|---------------|
+| `NOT_CHANGED`     | No change detected in the button state since last check.| 0             |
+| `SINGLE_CLICK`    | The button was clicked once.                            | 1             |
+| `DOUBLE_CLICK`    | The button was clicked twice in quick succession.       | 2             |
+| `TRIPLE_CLICK`    | The button was clicked three times in quick succession. | 3             |
+| `QUADRUPLE_CLICK` | The button was clicked four times in quick succession.  | 4             |
+| `QUINTUPLE_CLICK` | The button was clicked five times in quick succession.  | 5             |
+| `SEXTUPLE_CLICK`  | The button was clicked six times in quick succession.   | 6             |
+| `SEPTUPLE_CLICK`  | The button was clicked seven times in quick succession. | 7             |
+| `OCTUPLE_CLICK`   | The button was clicked eight times in quick succession. | 8             |
+| `NONUPLE_CLICK`   | The button was clicked nine times in quick succession.  | 9             |
+| `DECUPLE_CLICK`   | The button was clicked ten times in quick succession.   | 10            |
+| `PRESSED`         | The button is currently being pressed.                  | 11            |
+| `RELEASED`        | The button has been released after a press.             | 12            |

--- a/ros/riberry_startup/launch/atoms3_button_state_publisher.launch
+++ b/ros/riberry_startup/launch/atoms3_button_state_publisher.launch
@@ -4,13 +4,15 @@
 
   <group if="$(eval len(arg('namespace')) > 0)" ns="$(arg namespace)" >
     <node name="atom_s3_button_publisher"
-          pkg="riberry_startup" type="i2c_button_state_publisher" >
+          pkg="riberry_startup" type="i2c_button_state_publisher"
+          output="screen">
       <remap from="/i2c_button_state" to="/$(arg namespace)/atom_s3_button_state" />
     </node>
   </group>
   <group unless="$(eval len(arg('namespace')) > 0)">
     <node name="atom_s3_button_publisher"
-          pkg="riberry_startup" type="i2c_button_state_publisher" >
+          pkg="riberry_startup" type="i2c_button_state_publisher"
+          output="screen">
       <remap from="/i2c_button_state" to="/atom_s3_button_state" />
     </node>
   </group>

--- a/ros/riberry_startup/launch/atoms3_button_state_publisher.launch
+++ b/ros/riberry_startup/launch/atoms3_button_state_publisher.launch
@@ -1,0 +1,18 @@
+<launch>
+
+  <arg name="namespace" default="" />
+
+  <group if="$(eval len(arg('namespace')) > 0)" ns="$(arg namespace)" >
+    <node name="atom_s3_button_publisher"
+          pkg="riberry_startup" type="i2c_button_state_publisher" >
+      <remap from="/i2c_button_state" to="/$(arg namespace)/atom_s3_button_state" />
+    </node>
+  </group>
+  <group unless="$(eval len(arg('namespace')) > 0)">
+    <node name="atom_s3_button_publisher"
+          pkg="riberry_startup" type="i2c_button_state_publisher" >
+      <remap from="/i2c_button_state" to="/atom_s3_button_state" />
+    </node>
+  </group>
+
+</launch>

--- a/ros/riberry_startup/launch/riberry_startup.launch
+++ b/ros/riberry_startup/launch/riberry_startup.launch
@@ -1,0 +1,15 @@
+<launch>
+
+  <arg name="namespace" default="" />
+
+  <group if="$(eval len(arg('namespace')) > 0)" ns="$(arg namespace)" >
+    <include file="$(find riberry_startup)/launch/atoms3_button_state_publisher.launch" >
+      <arg name="namespace" value="$(arg namespace)" />
+    </include>
+  </group>
+  <group unless="$(eval len(arg('namespace')) > 0)">
+    <include file="$(find riberry_startup)/launch/atoms3_button_state_publisher.launch" >
+    </include>
+  </group>
+
+</launch>

--- a/ros/riberry_startup/src/i2c_button_state_publisher.cpp
+++ b/ros/riberry_startup/src/i2c_button_state_publisher.cpp
@@ -249,7 +249,7 @@ int main(int argc, char **argv) {
   int i2c_addr;
 
   private_nh.param<std::string>("i2c_device", i2c_device, "/dev/i2c-1");
-  private_nh.param("buffer_size", buffer_size, 100);
+  private_nh.param("buffer_size", buffer_size, 6);
   private_nh.param("i2c_addr", i2c_addr, 0x42);
   private_nh.param<std::string>("i2c_lock_file", i2c_lock_file, "/tmp/i2c-1.lock");
 
@@ -293,6 +293,8 @@ int main(int argc, char **argv) {
       continue;
     }
 
+    // expected bytes no 2 1 6 0 0 4
+    //         one click 2 1 6 1 94 4
     rxBuffer.resize(bytesRead);
     unpacker.reset();
     unpacker.write_data_list(rxBuffer);

--- a/ros/riberry_startup/src/i2c_button_state_publisher.cpp
+++ b/ros/riberry_startup/src/i2c_button_state_publisher.cpp
@@ -1,0 +1,311 @@
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <linux/i2c-dev.h>
+#include <ros/ros.h>
+#include <std_msgs/Int32.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <vector>
+
+int lockFile(int fd) {
+  struct flock fl;
+  fl.l_type = F_WRLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;
+
+  if (fcntl(fd, F_SETLKW, &fl) == -1) {
+    std::cerr << "Locking failed: " << strerror(errno) << std::endl;
+    return -1;
+  }
+  return 0;
+}
+
+int unlockFile(int fd) {
+  struct flock fl;
+  fl.l_type = F_UNLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;
+
+  if (fcntl(fd, F_SETLK, &fl) == -1) {
+    std::cerr << "Unlocking failed: " << strerror(errno) << std::endl;
+    return -1;
+  }
+  return 0;
+}
+
+class WireCrc {
+public:
+  WireCrc() : seed(0) {
+    table = generate_crc_table();
+  }
+
+  uint8_t calc(const std::vector<uint8_t>& data, size_t length) {
+    seed = 0;
+    return update(data, length);
+  }
+
+  uint8_t seed;
+  std::vector<uint8_t> table;
+
+  std::vector<uint8_t> generate_crc_table() {
+    std::vector<uint8_t> table(256);
+    for (int byte = 0; byte < 256; ++byte) {
+      uint8_t crc = byte;
+      for (int j = 0; j < 8; ++j) {
+        if (crc & 0x01) {
+          crc = (crc >> 1) ^ 0x8C;
+        } else {
+          crc >>= 1;
+        }
+      }
+      table[byte] = crc;
+    }
+    return table;
+  }
+
+  uint8_t update(const std::vector<uint8_t>& data, size_t length) {
+    uint8_t crc = seed;
+    for (size_t i = 0; i < length; ++i) {
+      uint8_t byte = data[i];
+      crc = table[crc ^ byte];
+    }
+    return crc;
+  }
+};
+
+
+class WireUnpacker {
+public:
+  enum Error {
+    NONE = 0,
+    INVALID_CRC = 1,
+    INVALID_LENGTH = 2
+  };
+
+  explicit WireUnpacker(size_t buffer_size) : buffer_size(buffer_size), buffer(buffer_size, 0), index(0), totalLength(0),
+                                              payloadLength(0), isPacketOpen(false), expectedLength(0), lastError(NONE) {
+    reset();
+  }
+
+  bool hasError() const {
+    return lastError != NONE;
+  }
+
+  int write(uint8_t data);
+
+  int write_data_list(const std::vector<uint8_t>& byte_data_list);
+
+  int write_array(const std::vector<uint8_t>& data) {
+    int count = 0;
+    for (uint8_t byte : data) {
+      count += write(byte);
+    }
+    return count;
+  }
+
+  size_t available() const {
+    return isPacketOpen ? 0 : payloadLength - index;
+  }
+
+  int read();
+
+  std::vector<uint8_t> getPayload() const {
+    if (payloadLength > 0) {
+      return std::vector<uint8_t>(buffer.begin(), buffer.begin() + payloadLength);
+    }
+    return std::vector<uint8_t>();
+  }
+
+  void reset() {
+    index = 0;
+    totalLength = 0;
+    expectedLength = 0;
+    payloadLength = 0;
+    isPacketOpen = false;
+    numBufferLength = 0;
+    lastError = NONE;
+    ignoreLength = 0;
+  }
+
+private:
+  size_t buffer_size;
+  std::vector<uint8_t> buffer;
+  size_t index;
+  size_t totalLength;
+  size_t payloadLength;
+  bool isPacketOpen;
+  size_t expectedLength;
+  uint8_t expectedCrc;
+  Error lastError;
+  size_t numBufferLength;
+  size_t ignoreLength;
+  static const uint8_t frameStart = 0x02;
+  static const uint8_t frameEnd = 0x04;
+};
+
+
+int WireUnpacker::write(uint8_t data) {
+  if (totalLength >= buffer_size || hasError()) {
+    return 0;
+  }
+
+  if (!isPacketOpen) {
+    if (totalLength == 0 && data == frameStart) {
+      isPacketOpen = true;
+      totalLength += 1;
+      return 1;
+    }
+    return 0;
+  }
+
+  if (expectedLength == 0 || numBufferLength > 0) {
+    if (numBufferLength == 0) {
+      numBufferLength = data;
+      ignoreLength = numBufferLength == 1 ? 5 : (numBufferLength == 2 ? 6 : 7);
+      totalLength += 1;
+      return 1;
+    }
+
+    expectedLength = (expectedLength << 8) + data;
+    numBufferLength -= 1;
+    if (numBufferLength > 0) {
+      totalLength += 1;
+      return 1;
+    }
+
+    if (expectedLength > buffer_size) {
+      isPacketOpen = false;
+      lastError = INVALID_LENGTH;
+      return 0;
+    }
+
+    totalLength += 1;
+    return 1;
+  }
+
+  if (totalLength < (expectedLength - 1)) {
+    buffer[index] = data;
+    index += 1;
+    totalLength += 1;
+    return 1;
+  }
+
+  isPacketOpen = false;
+  totalLength += 1;
+
+  if (data != frameEnd) {
+    lastError = INVALID_LENGTH;
+    return 0;
+  }
+
+  payloadLength = totalLength - ignoreLength;
+
+  WireCrc crc8;
+  uint8_t crc = crc8.update(buffer, payloadLength);
+
+  if (crc != buffer[index - 1]) {
+    lastError = INVALID_CRC;
+    return 0;
+  }
+
+  index = 0;
+  return 1;
+}
+
+int WireUnpacker::write_data_list(const std::vector<uint8_t>& byte_data_list) {
+  int count = 0;
+  for (auto& data : byte_data_list) {
+    count += write(data);
+  }
+  return count;
+}
+
+int WireUnpacker::read() {
+  if (isPacketOpen || index >= payloadLength) {
+    return -1;
+  }
+  uint8_t value = buffer[index];
+  index += 1;
+  return value;
+}
+
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "i2c_button_state_publisher");
+  ros::NodeHandle nh;
+  ros::NodeHandle private_nh("~");
+
+  ros::Publisher pub = nh.advertise<std_msgs::Int32>("/i2c_button_state", 1);
+  ros::Duration(3.0).sleep();
+
+  std::string i2c_device;
+  std::string i2c_lock_file;
+  int buffer_size;
+  int i2c_addr;
+
+  private_nh.param<std::string>("i2c_device", i2c_device, "/dev/i2c-1");
+  private_nh.param("buffer_size", buffer_size, 100);
+  private_nh.param("i2c_addr", i2c_addr, 0x42);
+  private_nh.param<std::string>("i2c_lock_file", i2c_lock_file, "/tmp/i2c-1.lock");
+
+  int lock_file_descriptor = open(i2c_lock_file.c_str(), O_RDWR | O_CREAT, 0666);
+  int file_descriptor;
+
+  if ((file_descriptor = open(i2c_device.c_str(), O_RDWR)) < 0) {
+    ROS_ERROR("Failed to open the I2C bus");
+    return -1;
+  }
+  if (ioctl(file_descriptor, I2C_SLAVE, i2c_addr) < 0) {
+    ROS_ERROR("Failed to acquire bus access and/or talk to slave");
+    close(file_descriptor);
+    return -1;
+  }
+
+  std::vector<uint8_t> rxBuffer(buffer_size);
+
+  uint8_t write_buf[5] = {2, 1, 5, 0, 4};
+
+  WireUnpacker unpacker(buffer_size);
+
+  while (ros::ok()) {
+    ros::spinOnce();
+    if (lockFile(lock_file_descriptor) != 0) {
+      ROS_ERROR("Failed to lock file descriptor");
+      break;
+    }
+
+    write(file_descriptor, write_buf, sizeof(write_buf));
+    ros::Duration(0.05).sleep();
+    ssize_t bytesRead = read(file_descriptor, rxBuffer.data(), rxBuffer.size());
+
+    if (unlockFile(lock_file_descriptor) != 0) {
+      ROS_ERROR("Failed to unlock file descriptor");
+      break;
+    }
+
+    if (bytesRead <= 0) {
+      ROS_ERROR("Could not get packet.");
+      continue;
+    }
+
+    rxBuffer.resize(bytesRead);
+    unpacker.reset();
+    unpacker.write_data_list(rxBuffer);
+    std::vector<uint8_t> payload = unpacker.getPayload();
+    if (payload.size() != 1) {
+      ROS_ERROR("Failed to read button state");
+      continue;
+    }
+    std_msgs::Int32 button_state_msg;
+    button_state_msg.data = payload[0];
+    pub.publish(button_state_msg);
+  }
+  close(file_descriptor);
+  close(lock_file_descriptor);
+  return 0;
+}

--- a/ros/riberry_startup/src/i2c_button_state_publisher.cpp
+++ b/ros/riberry_startup/src/i2c_button_state_publisher.cpp
@@ -344,7 +344,9 @@ int main(int argc, char **argv) {
     unpacker.write_data_list(rxBuffer);
     std::vector<uint8_t> payload = unpacker.getPayload();
     if (payload.size() != 1) {
-      ROS_ERROR("Failed to read button state");
+      // This error occurs frequently, but after several attempts,
+      // the button value becomes readable, so throttle the output.
+      ROS_ERROR_THROTTLE(60.0, "Failed to read button state");
       continue;
     }
     std_msgs::Int32 button_state_msg;

--- a/ros/riberry_startup/systemd/riberry_startup.service
+++ b/ros/riberry_startup/systemd/riberry_startup.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Startup Riberry launch service
+After=roscore.service
+Requires=roscore.service
+
+[Service]
+EnvironmentFile=-/etc/opt/riberry/riberry.user
+Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
+ExecStart=/bin/bash -c '. $SETUP && export $(python $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup riberry_startup.launch'
+SyslogIdentifier=%n
+Restart=always
+RestartSec=10s
+Type=simple
+User=rock
+
+[Install]
+WantedBy=multi-user.target

--- a/ros/riberry_startup/systemd/riberry_startup.service
+++ b/ros/riberry_startup/systemd/riberry_startup.service
@@ -6,7 +6,7 @@ Requires=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup riberry_startup.launch'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup riberry_startup.launch'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s

--- a/ros/riberry_startup/systemd/roscore.service
+++ b/ros/riberry_startup/systemd/roscore.service
@@ -6,7 +6,7 @@ Requires=NetworkManager.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python $(rospack find riberry_startup)/scripts/get_roshost.py) && roscore'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roscore'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s

--- a/ros/riberry_startup/systemd/user.service
+++ b/ros/riberry_startup/systemd/user.service
@@ -6,7 +6,7 @@ Requires=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup user.launch --wait'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup user.launch --wait'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=9999s


### PR DESCRIPTION
I have implemented file locking when accessing I2C in the display_information.service to ensure proper display updates on the Atom S3 device and in the atoms3_button_state_publisher.launch to handle button state reading as separate programs.

The key point is to define file locking in C++ consistent with how it's done in Python, ensuring that the file locking is correctly executed. This consistent approach across different programming languages helps prevent resource conflicts and ensures that both display updates and button state readings operate without interference.

This change is part of our ongoing efforts to enhance system stability and reliability.