### PR TITLE
Enable ros for display information

### DIFF
--- a/systemd/display_information.service
+++ b/systemd/display_information.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/bin/display_information.py
+ExecStart=/bin/bash -c '. /opt/ros/noetic/setup.bash && /usr/bin/python3 /usr/local/bin/display_information.py'
 Restart=on-failure
 RestartSec=10
 SyslogIdentifier=%n


### PR DESCRIPTION
Riberry's atom S3 is designed to be utilized at system startup and does not depend on ROS. 
However, it is configured to receive messages from ROS to allow users to obtain additional information.
Users who do not use ROS can display messages as they have always done, while users who use ROS can display messages via ROS.








