### PR TITLE
Reduce user.service RestartSec to recover even if roscore.service restarts

### DIFF
--- a/ros/riberry_startup/systemd/user.service
+++ b/ros/riberry_startup/systemd/user.service
@@ -13,7 +13,7 @@ Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${m
 ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup user.launch --wait'
 SyslogIdentifier=%n
 Restart=always
-RestartSec=9999s
+RestartSec=10s
 Type=simple
 User=rock
 


### PR DESCRIPTION
When starting radxa, sometimes roscore.service fails to start.
https://gist.github.com/nakane11/85147af6ce3d99839fc531e1954f3b0c

At that time, user.service that requires roscore.service is also killed.

By reducing user.service's `RestartSec`, user.service restarts immediately.