### PR TITLE
Display text on the LCD during mode transition waiting time

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
@@ -20,8 +20,10 @@ void DisplayInformationMode::task(void *parameter) {
     // Display information
     else {
       instance->atoms3lcd.drawBlack();
-      instance->atoms3lcd.printColorText(instance->atoms3lcd.color_str);
-      instance->atoms3i2c.setRequestStr(instance->getModeName());
+      if (instance->atoms3lcd.color_str.isEmpty())
+        instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName());
+      else
+        instance->atoms3lcd.printColorText(instance->atoms3lcd.color_str);
       vTaskDelay(pdMS_TO_TICKS(1000));
     }
   }

--- a/firmware/atom_s3_i2c_display/lib/display_qrcode_mode/display_qrcode_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_qrcode_mode/display_qrcode_mode.cpp
@@ -19,8 +19,11 @@ void DisplayQRcodeMode::task(void *parameter) {
     }
     // Display QR code
     else {
-      instance->atoms3lcd.drawQRcode(instance->atoms3lcd.qrCodeData);
-      instance->atoms3i2c.setRequestStr(instance->getModeName());
+      instance->atoms3lcd.drawBlack();
+      if (instance->atoms3lcd.qrCodeData.isEmpty())
+        instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName());
+      else
+        instance->atoms3lcd.drawQRcode(instance->atoms3lcd.qrCodeData);
       vTaskDelay(pdMS_TO_TICKS(1000));
     }
   }

--- a/firmware/atom_s3_i2c_display/lib/pressure_control_mode/pressure_control_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pressure_control_mode/pressure_control_mode.cpp
@@ -20,7 +20,10 @@ void PressureControlMode::task(void *parameter) {
     // Display information
     else {
       instance->atoms3lcd.drawBlack();
-      instance->atoms3lcd.printColorText(instance->atoms3lcd.color_str);
+      if (instance->atoms3lcd.color_str.isEmpty())
+        instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName());
+      else
+        instance->atoms3lcd.printColorText(instance->atoms3lcd.color_str);
       vTaskDelay(pdMS_TO_TICKS(1000));
     }
   }

--- a/firmware/atom_s3_i2c_display/lib/servo_control_mode/servo_control_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/servo_control_mode/servo_control_mode.cpp
@@ -20,7 +20,10 @@ void ServoControlMode::task(void *parameter) {
     // Display information
     else {
       instance->atoms3lcd.drawBlack();
-      instance->atoms3lcd.printColorText(instance->atoms3lcd.color_str);
+      if (instance->atoms3lcd.color_str.isEmpty())
+        instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName());
+      else
+        instance->atoms3lcd.printColorText(instance->atoms3lcd.color_str);
       vTaskDelay(pdMS_TO_TICKS(1000));
     }
   }

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -41,7 +41,6 @@ void loop() {
     current_mode_index = (current_mode_index + 1) % num_modes;
     atoms3i2c.stopReceiveEvent();
     atoms3lcd.drawBlack();
-    atoms3lcd.printMessage("Wait for mode switch ...");
     delay(1000);
     atoms3lcd.resetLcdData();
     // Resume


### PR DESCRIPTION
In the current version, LCD is black during mode transition waiting time.
With this PR, "Waiting for ..." text is displayed on the LCD.