### PR TITLE
[WIP] Display wifi-connect QR code before ROS is up

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -293,30 +293,31 @@ class DisplayInformation(I2CBase):
         while not stop_event.is_set():
             mode = atom_s3_mode
             print(f"Mode: {mode} device_type: {self.device_type}")
-            if mode != "DisplayInformationMode" and mode != "DisplayQRcodeMode":
-                time.sleep(0.1)
-                continue
-            if ros_display_image_flag and ros_display_image is not None:
-                self.display_image(ros_display_image)
-            else:
-                if get_ip_address() is None:
-                    if self.device_type == "Raspberry Pi":
-                        ssid = f"raspi-{get_mac_address()}"
-                    elif self.device_type == "Radxa Zero":
-                        ssid = f"radxa-{get_mac_address()}"
-                    else:
-                        ssid = f"radxa-{get_mac_address()}"
-                    self.display_qrcode(f"WIFI:S:{ssid};T:nopass;;")
-                    time.sleep(3)
+            # Display the QR code when Wi-Fi is not connected,
+            # regardless of atom_s3_mode.
+            if get_ip_address() is None:
+                if self.device_type == "Raspberry Pi":
+                    ssid = f"raspi-{get_mac_address()}"
+                elif self.device_type == "Radxa Zero":
+                    ssid = f"radxa-{get_mac_address()}"
                 else:
-                    if mode == "DisplayInformationMode":
-                        self.display_information()
-                        time.sleep(3)
-                    elif mode == "DisplayQRcodeMode":
-                        self.display_qrcode()
-                        time.sleep(3)
-                    else:
-                        time.sleep(3)
+                    ssid = f"radxa-{get_mac_address()}"
+                self.display_qrcode(f"WIFI:S:{ssid};T:nopass;;")
+                time.sleep(3)
+                continue
+            # Display data according to mode
+            if mode == "DisplayInformationMode":
+                self.display_information()
+                time.sleep(3)
+            elif mode == "DisplayQRcodeMode":
+                self.display_qrcode()
+                time.sleep(3)
+            elif mode == "DisplayImageMode":  # not implemented
+                if ros_display_image_flag and ros_display_image is not None:
+                    self.display_image(ros_display_image)
+                    time.sleep(3)
+            else:
+                time.sleep(0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the previous update(https://github.com/iory/riberry/pull/47), the QR code was not displayed unless the `/atom_s3_mode` rostopic was received. This caused an issue where, if the device was not connected to Wi-Fi, roscore wouldn't start, and the Wi-Fi connection QR code wouldn't appear.

This pull request fixes that by ensuring the QR code is displayed even when ROS is not connected.