### PR TITLE
Rename kxr_fullbody_controller to fullbody_controller

### DIFF
--- a/ros/riberry_startup/node_scripts/button_action_manager.py
+++ b/ros/riberry_startup/node_scripts/button_action_manager.py
@@ -24,7 +24,7 @@ class ButtonActionManager(threading.Thread):
         # Pressure control
         self.pressure_control_state = {}
         rospy.Subscriber(
-            "/kxr_fullbody_controller/pressure_control_interface/state",
+            "/fullbody_controller/pressure_control_interface/state",
             PressureControl,
             callback=self.pressure_control_cb,
             queue_size=1,
@@ -32,7 +32,7 @@ class ButtonActionManager(threading.Thread):
         # Servo on off
         self.servo_on_states = None
         rospy.Subscriber(
-            "/kxr_fullbody_controller/servo_on_off_real_interface/state",
+            "/fullbody_controller/servo_on_off_real_interface/state",
             ServoOnOff,
             callback=self.servo_on_off_cb,
             queue_size=1,

--- a/ros/riberry_startup/node_scripts/pressure_control_mode.py
+++ b/ros/riberry_startup/node_scripts/pressure_control_mode.py
@@ -32,7 +32,7 @@ class PressureControlMode(I2CBase):
         # Pressure control
         self.pressure_control_state = {}
         rospy.Subscriber(
-            "/kxr_fullbody_controller/pressure_control_interface/state",
+            "/fullbody_controller/pressure_control_interface/state",
             PressureControl,
             callback=self.pressure_control_cb,
             queue_size=1,
@@ -42,7 +42,7 @@ class PressureControlMode(I2CBase):
         self.pressures = {}
         for idx in range(38, 66):
             rospy.Subscriber(
-                f"/kxr_fullbody_controller/pressure/{idx}",
+                f"/fullbody_controller/pressure/{idx}",
                 Float32,
                 self.read_pressure,
                 callback_args=idx,

--- a/ros/riberry_startup/node_scripts/servo_control_mode.py
+++ b/ros/riberry_startup/node_scripts/servo_control_mode.py
@@ -31,7 +31,7 @@ class ServoControlMode(I2CBase):
         # Servo on off
         self.servo_on_states = None
         rospy.Subscriber(
-            "/kxr_fullbody_controller/servo_on_off_real_interface/state",
+            "/fullbody_controller/servo_on_off_real_interface/state",
             ServoOnOff,
             callback=self.servo_on_off_cb,
             queue_size=1,


### PR DESCRIPTION
This PR is for renaming to align with the change from kxr_fullbody_controller to fullbody_controller as in [this PR](https://github.com/iory/rcb4/pull/84).