### PR TITLE
[atom s3] Add display image mode

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.cpp
@@ -36,7 +36,8 @@ void AtomS3I2C::receiveEvent(int howMany) {
         str += c;
     }
     // Check for JPEG packet header and update length if found
-    if (str.length() == 5 && (str[0] == instance->atoms3lcd.jpegPacketHeader[0]) && (str[1] == instance->atoms3lcd.jpegPacketHeader[1]) && (str[2] == instance->atoms3lcd.jpegPacketHeader[2])) {
+    if (instance->atoms3lcd.readyJpeg == false
+        && str.length() == 5 && (str[0] == instance->atoms3lcd.jpegPacketHeader[0]) && (str[1] == instance->atoms3lcd.jpegPacketHeader[1]) && (str[2] == instance->atoms3lcd.jpegPacketHeader[2])) {
         instance->atoms3lcd.jpegLength = (uint32_t)(str[3] << 8) | str[4];
         instance->atoms3lcd.currentJpegIndex = 0;
         instance->atoms3lcd.loadingJpeg = true;
@@ -49,6 +50,7 @@ void AtomS3I2C::receiveEvent(int howMany) {
             // End loading if the entire JPEG is received
             if (instance->atoms3lcd.currentJpegIndex >= instance->atoms3lcd.jpegLength) {
                 instance->atoms3lcd.loadingJpeg = false;
+                instance->atoms3lcd.readyJpeg = true;
             }
             return;
         } else {

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
@@ -134,4 +134,5 @@ void AtomS3LCD::resetLcdData() {
   resetColorStr();
   resetJpegBuf();
   resetQRcodeData();
+  mode_changed = true;
 }

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -85,6 +85,7 @@ public:
   static constexpr uint8_t jpegPacketHeader[3] = { 0xFF, 0xD8, 0xEA }; /**< JPEG image packet header identifier. */
   uint8_t jpegBuf[8000]; /**< Buffer to store JPEG image data. */
   bool loadingJpeg = false; /**< Indicates whether the system is currently loading a JPEG image. */
+  bool readyJpeg = false; /**< Indicates whether the JPEG image has been fully loaded and is ready for use. */
   uint32_t jpegLength; /**< Length of the JPEG image data in bytes. */
   uint32_t currentJpegIndex = 0; /**< Current index in the JPEG buffer. */
 

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -78,6 +78,8 @@ public:
   void resetQRcodeData();
   void resetLcdData();
 
+  bool mode_changed = false;
+
   // for color string
   String color_str; /**< Stores color-related text for display. */
 

--- a/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
@@ -1,0 +1,33 @@
+#include <display_image_mode.h>
+
+DisplayImageMode* DisplayImageMode::instance = nullptr;
+
+DisplayImageMode::DisplayImageMode(AtomS3LCD &lcd, AtomS3I2C &i2c)
+  : atoms3lcd(lcd), atoms3i2c(i2c), Mode("DisplayImageMode") {
+    instance = this;
+}
+
+void DisplayImageMode::task(void *parameter) {
+  while (true) {
+    instance->atoms3i2c.setRequestStr(instance->getModeName());
+    // Check for I2C timeout
+    if (instance->atoms3i2c.checkTimeout()) {
+      instance->atoms3lcd.drawNoDataReceived();
+      instance->atoms3lcd.printMessage(instance->getModeName());
+      vTaskDelay(pdMS_TO_TICKS(500));
+      continue;
+    }
+    // Display Image code
+    else {
+      if (instance->atoms3lcd.readyJpeg == true) {
+        instance->atoms3lcd.drawImage(instance->atoms3lcd.jpegBuf, instance->atoms3lcd.jpegLength);
+        instance->atoms3lcd.readyJpeg = false;
+      }
+      vTaskDelay(pdMS_TO_TICKS(100));
+    }
+  }
+}
+
+void DisplayImageMode::createTask(uint8_t xCoreID) {
+  xTaskCreatePinnedToCore(task, "Display Image Mode", 2048, NULL, 1, &taskHandle, xCoreID);
+}

--- a/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
@@ -19,6 +19,11 @@ void DisplayImageMode::task(void *parameter) {
     }
     // Display Image code
     else {
+      if (instance->atoms3lcd.mode_changed) {
+        instance->atoms3lcd.drawBlack();
+        instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName() + ". \x1b[31mrosparam set \x1b[32m/display_image <Your Image Topic>\x1b[39m");
+        instance->atoms3lcd.mode_changed = false;
+      }
       if (instance->atoms3lcd.readyJpeg == true) {
         instance->atoms3lcd.drawImage(instance->atoms3lcd.jpegBuf, instance->atoms3lcd.jpegLength);
         instance->atoms3lcd.readyJpeg = false;

--- a/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.h
@@ -1,0 +1,21 @@
+#ifndef DISPLAY_IMAGE_MODE_H
+#define DISPLAY_IMAGE_MODE_H
+
+#include <mode.h>
+#include <atom_s3_lcd.h>
+#include <atom_s3_i2c.h>
+
+class DisplayImageMode : public Mode {
+public:
+  DisplayImageMode(AtomS3LCD &lcd, AtomS3I2C &i2c);
+  void createTask(uint8_t xCoreID) override;
+
+private:
+  static DisplayImageMode* instance; /**< Singleton instance of DisplayImageMode. */
+  AtomS3LCD &atoms3lcd;
+  AtomS3I2C &atoms3i2c;
+
+  static void task(void *parameter);
+};
+
+#endif // DISPLAY_IMAGE_MODE_H

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -3,6 +3,7 @@
 #include <atom_s3_button.h>
 #include <display_information_mode.h>
 #include <display_qrcode_mode.h>
+#include <display_image_mode.h>
 
 // Common tasks for AtomS3
 AtomS3Button atoms3button;
@@ -12,7 +13,8 @@ AtomS3I2C atoms3i2c(atoms3lcd, atoms3button);
 // User-defined modes:
 DisplayInformationMode display_information_mode(atoms3lcd, atoms3i2c);
 DisplayQRcodeMode display_qrcode_mode(atoms3lcd, atoms3i2c);
-Mode* modes[] = { &display_information_mode, &display_qrcode_mode };
+DisplayImageMode display_image_mode(atoms3lcd, atoms3i2c);
+Mode* modes[] = { &display_information_mode, &display_qrcode_mode, &display_image_mode };
 int current_mode_index = 0;
 int num_modes = sizeof(modes) / sizeof(modes[0]);
 


### PR DESCRIPTION
https://github.com/iory/riberry?tab=readme-ov-file#displaying-images-on-atom-s3
I added a mode to the Atom S3 to ensure the feature for displaying images in the README works correctly.