### PR TITLE
Add imu_orientation node

### DIFF
--- a/ros/riberry_startup/CMakeLists.txt
+++ b/ros/riberry_startup/CMakeLists.txt
@@ -25,8 +25,19 @@ endif()
 
 find_package(catkin REQUIRED COMPONENTS
   audio_common_msgs
+  message_generation
   roscpp
   sensor_msgs
+  std_msgs
+)
+
+add_message_files(
+  FILES
+  ImuFace.msg
+)
+
+generate_messages(
+  DEPENDENCIES
   std_msgs
 )
 

--- a/ros/riberry_startup/msg/ImuFace.msg
+++ b/ros/riberry_startup/msg/ImuFace.msg
@@ -1,8 +1,9 @@
-uint8 TOP=0
-uint8 BOTTOM=1
-uint8 FRONT=2
-uint8 BACK=3
-uint8 LEFT=4
-uint8 RIGHT=5
+uint8 NONE=0
+uint8 TOP=1
+uint8 BOTTOM=2
+uint8 FRONT=3
+uint8 BACK=4
+uint8 LEFT=5
+uint8 RIGHT=6
 
 uint8 face

--- a/ros/riberry_startup/msg/ImuFace.msg
+++ b/ros/riberry_startup/msg/ImuFace.msg
@@ -1,0 +1,8 @@
+uint8 TOP=0
+uint8 BOTTOM=1
+uint8 FRONT=2
+uint8 BACK=3
+uint8 LEFT=4
+uint8 RIGHT=5
+
+uint8 face

--- a/ros/riberry_startup/node_scripts/imu_orientation.py
+++ b/ros/riberry_startup/node_scripts/imu_orientation.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import numpy as np
+from riberry_startup.msg import ImuFace
+import rospy
+from sensor_msgs.msg import Imu
+
+
+class IMUOrientation:
+    def __init__(self):
+        self.imu_sub = rospy.Subscriber("~imu", Imu, self.imu_callback)
+        self.imu_orientation_pub = rospy.Publisher(
+            "~imu_face", ImuFace, queue_size=1)
+        self.threshold = rospy.get_param("~threshold", 0.8)
+
+    def imu_callback(self, msg):
+        acc_x = msg.linear_acceleration.x
+        acc_y = msg.linear_acceleration.y
+        acc_z = msg.linear_acceleration.z
+
+        # Normalize acceleration vector
+        acc = np.array([acc_x, acc_y, acc_z])
+        norm = np.linalg.norm(acc)
+        if norm == 0:
+            rospy.logwarn("Zero acceleration vector received.")
+            return
+        acc_normalized = acc / norm
+
+        # Select a closest face by calculating inner product
+        faces = {
+            ImuFace.TOP: np.array([0, 0, 1]),
+            ImuFace.BOTTOM: np.array([0, 0, -1]),
+            ImuFace.FRONT: np.array([0, 1, 0]),
+            ImuFace.BACK: np.array([0, -1, 0]),
+            ImuFace.LEFT: np.array([1, 0, 0]),
+            ImuFace.RIGHT: np.array([-1, 0, 0]),
+        }
+
+        best_match = None
+        best_similarity = -1
+        for face, direction in faces.items():
+            similarity = np.dot(acc_normalized, direction)
+            if similarity > best_similarity and similarity > self.threshold:
+                best_match = face
+                best_similarity = similarity
+        if best_match is None:
+            return
+
+        msg = ImuFace(face=best_match)
+        self.imu_orientation_pub.publish(msg)
+
+
+if __name__ == "__main__":
+    rospy.init_node("imu_orientation")
+    imu_orientation = IMUOrientation()
+    rospy.spin()

--- a/ros/riberry_startup/node_scripts/imu_orientation.py
+++ b/ros/riberry_startup/node_scripts/imu_orientation.py
@@ -22,6 +22,8 @@ class IMUOrientation:
         norm = np.linalg.norm(acc)
         if norm == 0:
             rospy.logwarn("Zero acceleration vector received.")
+            msg = ImuFace(face=ImuFace.NONE)
+            self.imu_orientation_pub.publish(msg)
             return
         acc_normalized = acc / norm
 
@@ -43,7 +45,7 @@ class IMUOrientation:
                 best_match = face
                 best_similarity = similarity
         if best_match is None:
-            return
+            best_match = ImuFace.NONE
 
         msg = ImuFace(face=best_match)
         self.imu_orientation_pub.publish(msg)


### PR DESCRIPTION
To change the behavior of a robot with suction function depending on the direction it is attached, the side facing down is published as  `imu_face` .
The larger the `threshold` param, the less likely it is to change to the next direction even if the imu is tilted.

In case of kondoh7, the side with the connector is TOP and the other side is BOTTOM.
The side with the VH connector is BACK, and the side with the Grove connector is the FRONT.