### PR TITLE
Multi motion recording and playing in teaching mode

### DIFF
--- a/firmware/atom_s3_i2c_display/README.md
+++ b/firmware/atom_s3_i2c_display/README.md
@@ -107,6 +107,8 @@ The following sections provide details on the base code for the AtomS3 firmware.
   - After recording, the state automatically returns to `WAIT`.
 
   In the `PLAY` state:
-  - Playing motion automatically starts at the moment of transition from `WAIT` state to `PLAY` state
-  - A double click stops playing motion.
-  - After playback, the state automatically returns to `WAIT`.
+  - A single click toggles the selected motion. The current selection is indicated by green.
+  - A double click starts playing the selected motion.
+    - After starting, a double click stops playing motion.
+  - A triple click deletes the selected motion.
+  - After playback or delete, the state automatically returns to `WAIT`.

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -1,0 +1,117 @@
+import json
+import os
+from pathlib import Path
+
+from kxr_controller.kxr_interface import KXRROSRobotInterface
+import numpy as np
+import rospy
+from skrobot.model import RobotModel
+
+
+class MotionManager:
+    def __init__(self):
+        # skrobot version check
+        from packaging import version
+        import skrobot
+        required_version = "0.0.44"
+        current_version = skrobot.__version__
+        if version.parse(current_version) < version.parse(required_version):
+            raise Exception(f"skrobot version is not greater than {required_version}. (current version: {current_version})\npip install scikit-robot -U")
+        # Create robot model to control pressure
+        robot_model = RobotModel()
+        namespace = ""
+        robot_model.load_urdf_from_robot_description(namespace + "/robot_description_viz")
+        self.ri = KXRROSRobotInterface(
+            robot_model, namespace=namespace, controller_timeout=60.0
+        )
+        self.joint_names = self.ri.robot.joint_names
+        # Teaching motion json
+        self.json_filepath = os.path.join(str(Path.cwd()), 'teaching_motion.json')
+        self.motion = []
+        self.stop = False
+
+    def add_motion(self):
+        """
+        Add current pose to self.motion
+"""
+        if len(self.motion) == 0:
+            self.start_time = rospy.Time.now()
+        joint_states = {}
+        av = self.ri.angle_vector()
+        for j, a in zip(self.joint_names, av):
+            joint_states[str(j)] = float(a)
+        now = rospy.Time.now()
+        elapsed_time = (now - self.start_time).to_sec()
+        self.motion.append({
+            'time': elapsed_time,
+            'joint_states': joint_states,
+        })
+        rospy.loginfo('Add new joint states')
+        rospy.loginfo(f'Time: {elapsed_time}, joint_states: {joint_states}')
+
+    def stop(self):
+        self.stop = True
+
+    def record(self):
+        self.motion = []
+        with open(self.json_filepath, mode='w') as f:
+            rospy.loginfo(f'Start saving motion to {self.json_filepath}')
+            while not rospy.is_shutdown():
+                # Finish recording
+                if self.stop is True:
+                    break
+                self.add_motion()
+                rospy.sleep(0.1)
+            f.write(json.dumps(self.motion, indent=4, separators=(",", ": ")))
+            rospy.loginfo(f'Finish saving motion to {self.json_filepath}')
+
+    def play(self):
+        # Load motion
+        if os.path.exists(self.json_filepath):
+            rospy.loginfo(f'Load motion data file {self.json_filepath}.')
+            with open(self.json_filepath) as f:
+                self.motion = json.load(f)
+        # Play motion
+        rospy.loginfo('Play motion')
+        self.ri.servo_on()
+        # To prevent sudden movement, take time to reach the initial motion
+        if 'joint_states' not in self.motion[0]:
+            print("First element must have 'joint_states' key.")
+            return
+        first_av = list(self.motion[0]['joint_states'].values())
+        self.ri.angle_vector(first_av, 3)
+        self.ri.wait_interpolation()
+        # Play the actions from the second one onward
+        prev_time = self.motion[0]['time']
+        avs = []
+        tms = []
+        for motion in self.motion[1:]:
+            current_time = motion['time']
+            # Send angle vector
+            if 'joint_states' in motion:
+                av = np.array(list(motion['joint_states'].values()))
+                avs.append(av)
+                tms.append(current_time - prev_time)
+            prev_time = current_time
+        rospy.loginfo('angle vectors')
+        rospy.loginfo(f'{avs}')
+        rospy.loginfo('times')
+        rospy.loginfo(f'{tms}')
+        self.ri.angle_vector_sequence(avs, tms)
+        # Check interruption by button
+        # use self.ri.is_interpolating() after the following PR is merged
+        # https://github.com/iory/scikit-robot/pull/396
+        def is_interpolating(controller_type=None):
+            if controller_type:
+                controller_actions = self.ri.controller_table[controller_type]
+            else:
+                controller_actions = self.ri.controller_table[self.ri.controller_type]
+            is_interpolatings = (action.is_interpolating() for action in controller_actions)
+            return any(list(is_interpolatings))
+        while not rospy.is_shutdown() and is_interpolating():
+            if self.stop is True:
+                self.ri.cancel_angle_vector()
+                rospy.loginfo('Play interrupted')
+                break
+            rospy.sleep(0.5)  # Save motion every 0.5s to smooth motion play
+        rospy.loginfo('Play finished')

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -12,7 +12,7 @@ class MotionManager:
         # skrobot version check
         from packaging import version
         import skrobot
-        required_version = "0.0.44"
+        required_version = "0.0.45"
         current_version = skrobot.__version__
         if version.parse(current_version) < version.parse(required_version):
             raise Exception(f"skrobot version is not greater than {required_version}. (current version: {current_version})\npip install scikit-robot -U")
@@ -101,16 +101,7 @@ class MotionManager:
         rospy.loginfo(f'{tms}')
         self.ri.angle_vector_sequence(avs, tms)
         # Check interruption by button
-        # use self.ri.is_interpolating() after the following PR is merged
-        # https://github.com/iory/scikit-robot/pull/396
-        def is_interpolating(controller_type=None):
-            if controller_type:
-                controller_actions = self.ri.controller_table[controller_type]
-            else:
-                controller_actions = self.ri.controller_table[self.ri.controller_type]
-            is_interpolatings = (action.is_interpolating() for action in controller_actions)
-            return any(list(is_interpolatings))
-        while not rospy.is_shutdown() and is_interpolating():
+        while not rospy.is_shutdown() and self.ri.is_interpolating():
             if self._stop is True:
                 self.ri.cancel_angle_vector()
                 rospy.loginfo('Play interrupted')

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -1,6 +1,5 @@
 import json
 import os
-from pathlib import Path
 
 from kxr_controller.kxr_interface import KXRROSRobotInterface
 import numpy as np
@@ -25,8 +24,6 @@ class MotionManager:
             robot_model, namespace=namespace, controller_timeout=60.0
         )
         self.joint_names = self.ri.robot.joint_names
-        # Teaching motion json
-        self.json_filepath = os.path.join(str(Path.cwd()), 'teaching_motion.json')
         self.motion = []
         self._stop = False
 
@@ -55,11 +52,11 @@ class MotionManager:
     def servo_off(self):
         self.ri.servo_off()
 
-    def record(self):
+    def record(self, record_filepath):
         self._stop = False
         self.motion = []
-        with open(self.json_filepath, mode='w') as f:
-            rospy.loginfo(f'Start saving motion to {self.json_filepath}')
+        with open(record_filepath, mode='w') as f:
+            rospy.loginfo(f'Start saving motion to {record_filepath}')
             while not rospy.is_shutdown():
                 # Finish recording
                 if self._stop is True:
@@ -67,14 +64,14 @@ class MotionManager:
                 self.add_motion()
                 rospy.sleep(0.1)
             f.write(json.dumps(self.motion, indent=4, separators=(",", ": ")))
-            rospy.loginfo(f'Finish saving motion to {self.json_filepath}')
+            rospy.loginfo(f'Finish saving motion to {record_filepath}')
 
-    def play(self):
+    def play(self, play_filepath):
         self._stop = False
         # Load motion
-        if os.path.exists(self.json_filepath):
-            rospy.loginfo(f'Load motion data file {self.json_filepath}.')
-            with open(self.json_filepath) as f:
+        if os.path.exists(play_filepath):
+            rospy.loginfo(f'Load motion data file {play_filepath}.')
+            with open(play_filepath) as f:
                 self.motion = json.load(f)
         # Play motion
         rospy.loginfo('Play motion')

--- a/riberry/select_list.py
+++ b/riberry/select_list.py
@@ -2,20 +2,28 @@ import re
 
 
 class SelectList:
-    def __init__(self):
-        self.options = []
+    def __init__(self, items=None):
+        if isinstance(items, list):
+            self.options = items
+        else:
+            self.options = []
         self.idx = 0
         self.pattern = None
 
     def add_option(self, item):
-            self.options.insert(0, item)
+        self.options.insert(0, item)
+
+    def remove_option(self, item):
+        self.options.remove(item)
+        if self.idx >= len(self.options):
+            self.idx = 0
 
     def increment_index(self):
         self.idx += 1
         if self.idx >= len(self.options):
             self.idx = 0
 
-    def get_selected(self, extract=False):
+    def selected_option(self, extract=False):
         if len(self.options) <= self.idx:
             return None
         selected = self.options[self.idx]
@@ -24,25 +32,26 @@ class SelectList:
         else:
             return selected
 
-    def get_list_string(self, num):
+    def string_list(self, max_num):
         sent_str = ''
-        if self.idx < num:
-            for i, item in enumerate(self.options[:num]):
-                item = self.pattern.search(item).group(1)
-                if i == self.idx:
-                    sent_str += '\x1b[32m' + item
-                else:
-                    sent_str += '\x1b[37m' + item
-                sent_str += '\x1b[0m\n'
+        if not self.options:
+            return sent_str
+
+        if self.idx < max_num:
+            display_options = self.options[:max_num]
+            highlight_idx = self.idx
         else:
-            for i, item in enumerate(self.options[self.idx-num+1:self.idx+1]):
-                item = self.pattern.search(item).group(1)
-                if i == num-1:
-                    sent_str += '\x1b[32m' + item + '\x1b[0m'
-                else:
-                    sent_str += item
-                sent_str += '\n'
+            display_options = self.options[self.idx-max_num+1:self.idx+1]
+            highlight_idx = max_num - 1
+
+        for i, item in enumerate(display_options):
+            if self.pattern:
+                match = self.pattern.search(item)
+                item = match.group(1) if match else item
+            color_code = "\x1b[32m" if i == highlight_idx else "\x1b[39m"
+            sent_str += f"{color_code}{item}\n"
+        sent_str += '\x1b[39m'
         return sent_str
 
-    def add_extract_pattern(self, pattern):
+    def set_extract_pattern(self, pattern):
         self.pattern = re.compile(pattern)

--- a/riberry/select_list.py
+++ b/riberry/select_list.py
@@ -32,7 +32,7 @@ class SelectList:
         else:
             return selected
 
-    def string_list(self, max_num):
+    def string_options(self, max_num):
         sent_str = ''
         if not self.options:
             return sent_str

--- a/riberry/select_list.py
+++ b/riberry/select_list.py
@@ -19,9 +19,10 @@ class SelectList:
             self.idx = 0
 
     def increment_index(self):
-        self.idx += 1
-        if self.idx >= len(self.options):
-            self.idx = 0
+        if len(self.options) == 0:
+            return -1
+        self.idx = (self.idx + 1) % len(self.options)
+        return self.idx
 
     def selected_option(self, extract=False):
         if len(self.options) <= self.idx:

--- a/riberry/select_list.py
+++ b/riberry/select_list.py
@@ -1,0 +1,48 @@
+import re
+
+
+class SelectList:
+    def __init__(self):
+        self.options = []
+        self.idx = 0
+        self.pattern = None
+
+    def add_option(self, item):
+            self.options.insert(0, item)
+
+    def increment_index(self):
+        self.idx += 1
+        if self.idx >= len(self.options):
+            self.idx = 0
+
+    def get_selected(self, extract=False):
+        if len(self.options) <= self.idx:
+            return None
+        selected = self.options[self.idx]
+        if extract:
+            return self.pattern.search(selected).group(1)
+        else:
+            return selected
+
+    def get_list_string(self, num):
+        sent_str = ''
+        if self.idx < num:
+            for i, item in enumerate(self.options[:num]):
+                item = self.pattern.search(item).group(1)
+                if i == self.idx:
+                    sent_str += '\x1b[32m' + item
+                else:
+                    sent_str += '\x1b[37m' + item
+                sent_str += '\x1b[0m\n'
+        else:
+            for i, item in enumerate(self.options[self.idx-num+1:self.idx+1]):
+                item = self.pattern.search(item).group(1)
+                if i == num-1:
+                    sent_str += '\x1b[32m' + item + '\x1b[0m'
+                else:
+                    sent_str += item
+                sent_str += '\n'
+        return sent_str
+
+    def add_extract_pattern(self, pattern):
+        self.pattern = re.compile(pattern)

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -72,21 +72,19 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
                 self.motion_manager.servo_off()
         elif self.state == State.PLAY:
             if self.playing is False:
+                if msg.data != 0 and len(self.play_list.options) <= 0:
+                    self.state = State.WAIT
+                    return
                 # select play file
                 if msg.data == 1:
                     self.play_list.increment_index()
                 # confirm play file
                 elif msg.data == 2:
                     self.play_file = self.play_list.selected_option()
-                    if self.play_file is None:
-                        self.state = State.WAIT
-                    else:
-                        self.playing = True
+                    self.playing = True
                 # delete play file
                 elif msg.data == 3:
                     delete_file = self.play_list.selected_option()
-                    if delete_file is None:
-                        self.state = State.WAIT
                     if os.path.exists(delete_file):
                         os.remove(delete_file)
                     self.play_list.remove_option(delete_file)
@@ -111,11 +109,16 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
                 + '1tap: finish'
         elif self.state == State.PLAY:
             if self.playing is False:
-                sent_str += 'Play mode\n'\
-                    + ' 1tap: select\n'\
-                    + ' 2tap: start\n'\
-                    + ' 3tap: delete\n\n'
-                sent_str += self.play_list.string_options(5)
+                if len(self.play_list.options) <= 0:
+                    sent_str += 'Play mode\n\n'\
+                        + 'No motion\n'\
+                        + ' 1 tap: return'
+                else:
+                    sent_str += 'Play mode\n'\
+                        + ' 1tap: select\n'\
+                        + ' 2tap: start\n'\
+                        + ' 3tap: delete\n\n'
+                    sent_str += self.play_list.string_options(5)
             else:
                 sent_str += 'Play mode\n\n'\
                     + f'{self.play_list.selected_option(True)}\n\n'\

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+from datetime import datetime
 from enum import Enum
+import os
 
 import rospy
 from std_msgs.msg import Int32
@@ -8,6 +10,7 @@ from std_msgs.msg import String
 
 from riberry.i2c_base import I2CBase
 from riberry.motion_manager import MotionManager
+from riberry.select_list import SelectList
 
 
 class State(Enum):
@@ -15,12 +18,18 @@ class State(Enum):
     RECORD = 1
     PLAY = 2
 
+
 class TeachingMode(I2CBase):
     def __init__(self, i2c_addr, lock_path="/tmp/teaching_mode.lock"):
         super().__init__(i2c_addr)
         self.motion_manager = MotionManager()
-        # Button and mode callback
+        self.ros_dir = os.path.join(os.environ["HOME"], ".ros")
+        self.select_list = SelectList()
+        self.select_list.add_extract_pattern(r"teaching_(.*?)\.json")
+        self.add_teaching_files()
+        self.motion_file = None
         self.mode = None
+        # Button and mode callback
         rospy.Subscriber(
             "/atom_s3_button_state",
             Int32, callback=self.button_cb, queue_size=1)
@@ -58,9 +67,17 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
                 self.motion_manager.stop()
                 self.state = State.WAIT
         elif self.state == State.PLAY:
-            if msg.data == 2:
-                self.motion_manager.stop()
-                self.state = State.WAIT
+            if self.motion_file is None:
+                if msg.data == 1:
+                    self.select_list.increment_index()
+                elif msg.data == 2:
+                    self.motion_file = self.select_list.get_selected()
+                    if self.motion_file is None:
+                        self.state = State.WAIT
+            else:
+                if msg.data == 2:
+                    self.motion_manager.stop()
+                    self.state = State.WAIT
 
     def timer_callback(self, event):
         if self.mode != "TeachingMode":
@@ -75,9 +92,36 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
             sent_str += 'Record mode\n\n'\
                 + 'single click:\n  stop recording'
         elif self.state == State.PLAY:
-            sent_str += 'Play mode\n\n'\
-                + 'double click:\n  stop playing'
+            if self.motion_file is None:
+                sent_str += 'Play mode\n\n'\
+                    + 'double click: start playing\n\n'
+                sent_str += self.select_list.get_list_string(5)
+            else:
+                sent_str += 'Play mode\n\n'\
+                    + f'{self.select_list.get_selected(True)}\n\n'\
+                    + 'double click:\n  stop playing'
         self.send_string(sent_str)
+
+    def add_teaching_files(self):
+        teaching_files = [
+            os.path.join(self.ros_dir, file) for file in os.listdir(self.ros_dir)
+            if file.startswith("teaching_") and file.endswith(".json")
+        ]
+
+        teaching_files_sorted = sorted(
+            teaching_files,
+            key=lambda f: os.path.getctime(f)
+        )
+        for file in teaching_files_sorted:
+            self.select_list.add_option(file)
+
+    def get_json_filepath(self, filename=None):
+        if filename is not None:
+            json_filepath = os.path.join(self.ros_dir, f'teaching_{filename}.json')
+        else:
+            current_time = datetime.now().strftime("%m%d_%H%M%S")
+            json_filepath = os.path.join(self.ros_dir, f'teaching_{current_time}.json')
+        return json_filepath
 
     def main_loop(self):
         rospy.loginfo('start teaching mode')
@@ -89,11 +133,17 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
                 if self.state == State.WAIT:
                     rospy.sleep(1)
                 elif self.state == State.RECORD:
-                    self.motion_manager.record()
+                    motion_path = self.get_json_filepath()
+                    self.motion_manager.record(motion_path)
+                    self.select_list.add_option(motion_path)
                     self.state = State.WAIT
                 elif self.state == State.PLAY:
-                    self.motion_manager.play()
-                    self.state = State.WAIT
+                    if self.motion_file is None:
+                        continue
+                    else:
+                        self.motion_manager.play(self.motion_file)
+                        self.motion_file = None
+                        self.state = State.WAIT
         except KeyboardInterrupt:
             print('Finish teaching mode by KeyboardInterrupt')
             exit()

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
 
 from enum import Enum
-import json
-import os
-from pathlib import Path
 
-from kxr_controller.kxr_interface import KXRROSRobotInterface
-import numpy as np
 import rospy
-from skrobot.model import RobotModel
 from std_msgs.msg import Int32
 from std_msgs.msg import String
 
@@ -23,17 +17,7 @@ class State(Enum):
 class TeachingMode(I2CBase):
     def __init__(self, i2c_addr, lock_path="/tmp/teaching_mode.lock"):
         super().__init__(i2c_addr)
-        # Create robot model to control pressure
-        robot_model = RobotModel()
-        namespace = ""
-        robot_model.load_urdf_from_robot_description(namespace + "/robot_description_viz")
-        self.ri = KXRROSRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
-        )
-        self.joint_names = self.ri.robot.joint_names
-        # Teaching motion json
-        self.json_filepath = os.path.join(str(Path.cwd()), 'teaching_motion.json')
-        self.motion = []
+        self.motion_manager = MotionManager()
         # Button and mode callback
         self.mode = None
         rospy.Subscriber(
@@ -75,89 +59,6 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
             if msg.data == 2:
                 self.state = State.WAIT
 
-    def add_motion(self):
-        """
-        Add current pose to self.motion
-"""
-        if len(self.motion) == 0:
-            self.start_time = rospy.Time.now()
-        joint_states = {}
-        av = self.ri.angle_vector()
-        for j, a in zip(self.joint_names, av):
-            joint_states[str(j)] = float(a)
-        now = rospy.Time.now()
-        elapsed_time = (now - self.start_time).to_sec()
-        self.motion.append({
-            'time': elapsed_time,
-            'joint_states': joint_states,
-        })
-        rospy.loginfo('Add new joint states')
-        rospy.loginfo(f'Time: {elapsed_time}, joint_states: {joint_states}')
-
-    def record(self):
-        self.motion = []
-        with open(self.json_filepath, mode='w') as f:
-            rospy.loginfo(f'Start saving motion to {self.json_filepath}')
-            while not rospy.is_shutdown():
-                # Finish recording
-                if self.state == State.WAIT:
-                    break
-                self.add_motion()
-                rospy.sleep(0.1)
-            f.write(json.dumps(self.motion, indent=4, separators=(",", ": ")))
-            rospy.loginfo(f'Finish saving motion to {self.json_filepath}')
-
-    def play(self):
-        # Load motion
-        if os.path.exists(self.json_filepath):
-            rospy.loginfo(f'Load motion data file {self.json_filepath}.')
-            with open(self.json_filepath) as f:
-                self.motion = json.load(f)
-        # Play motion
-        rospy.loginfo('Play motion')
-        self.ri.servo_on()
-        # To prevent sudden movement, take time to reach the initial motion
-        if 'joint_states' not in self.motion[0]:
-            print("First element must have 'joint_states' key.")
-            return
-        first_av = list(self.motion[0]['joint_states'].values())
-        self.ri.angle_vector(first_av, 3)
-        self.ri.wait_interpolation()
-        # Play the actions from the second one onward
-        prev_time = self.motion[0]['time']
-        avs = []
-        tms = []
-        for motion in self.motion[1:]:
-            current_time = motion['time']
-            # Send angle vector
-            if 'joint_states' in motion:
-                av = np.array(list(motion['joint_states'].values()))
-                avs.append(av)
-                tms.append(current_time - prev_time)
-            prev_time = current_time
-        rospy.loginfo('angle vectors')
-        rospy.loginfo(f'{avs}')
-        rospy.loginfo('times')
-        rospy.loginfo(f'{tms}')
-        self.ri.angle_vector_sequence(avs, tms)
-        # Check interruption by button
-        # use self.ri.is_interpolating() after the following PR is merged
-        # https://github.com/iory/scikit-robot/pull/396
-        def is_interpolating(controller_type=None):
-            if controller_type:
-                controller_actions = self.ri.controller_table[controller_type]
-            else:
-                controller_actions = self.ri.controller_table[self.ri.controller_type]
-            is_interpolatings = (action.is_interpolating() for action in controller_actions)
-            return any(list(is_interpolatings))
-        while not rospy.is_shutdown() and is_interpolating():
-            if self.state == State.WAIT:
-                self.ri.cancel_angle_vector()
-                rospy.loginfo('Play interrupted')
-                break
-            rospy.sleep(0.5)  # Save motion every 0.5s to smooth motion play
-        rospy.loginfo('Play finished')
-
     def timer_callback(self, event):
         if self.mode != "TeachingMode":
             return
@@ -183,12 +84,13 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
                     rospy.sleep(1)
                     continue
                 if self.state == State.WAIT:
+                    self.motion_manager.stop()
                     rospy.sleep(1)
                 elif self.state == State.RECORD:
-                    self.record()
+                    self.motion_manager.record()
                     self.state = State.WAIT
                 elif self.state == State.PLAY:
-                    self.play()
+                    self.motion_manager.play()
                     self.state = State.WAIT
         except KeyboardInterrupt:
             print('Finish teaching mode by KeyboardInterrupt')
@@ -196,13 +98,6 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
 
 
 if __name__ == '__main__':
-    # skrobot version check
-    from packaging import version
-    import skrobot
-    required_version = "0.0.44"
-    current_version = skrobot.__version__
-    if version.parse(current_version) < version.parse(required_version):
-        raise Exception(f"skrobot version is not greater than {required_version}. (current version: {current_version})\npip install scikit-robot -U")
     # Main
     rospy.init_node('teaching_mode', anonymous=True)
     tm = TeachingMode(0x42)

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -7,6 +7,7 @@ from std_msgs.msg import Int32
 from std_msgs.msg import String
 
 from riberry.i2c_base import I2CBase
+from riberry.motion_manager import MotionManager
 
 
 class State(Enum):
@@ -41,7 +42,7 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
         if self.mode != "TeachingMode":
             return
         if msg.data == 3:
-            self.ri.servo_off()
+            self.motion_manager.servo_off()
         if self.prev_state != self.state:
             sent_str = f'State: {self.state.name}'
             rospy.loginfo(sent_str)
@@ -54,9 +55,11 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
                 self.state = State.PLAY
         elif self.state == State.RECORD:
             if msg.data == 1:
+                self.motion_manager.stop()
                 self.state = State.WAIT
         elif self.state == State.PLAY:
             if msg.data == 2:
+                self.motion_manager.stop()
                 self.state = State.WAIT
 
     def timer_callback(self, event):
@@ -84,7 +87,6 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Abort -> Wait
                     rospy.sleep(1)
                     continue
                 if self.state == State.WAIT:
-                    self.motion_manager.stop()
                     rospy.sleep(1)
                 elif self.state == State.RECORD:
                     self.motion_manager.record()


### PR DESCRIPTION
## Overview
Previously, since the same json file was being rewritten, only one motion could be recorded and played. This PR enables recording and playing multiple motions by introducing SelectList, an interface class for selecting specific elements from a list.
 
 In the PLAY state, transition with button is as follows:
| click | operation |
| ---- | ---- |
|1|toggle the selected motion|
|2|start playing the selected motion|
|3|delete the selected motion|


https://github.com/user-attachments/assets/1edb5516-3fe2-4ffd-9101-b8c8fb5f7b5b



Note that there are few types of clicks and no function to go back to the previous menu, so you will automatically be in a WAIT state after deleting the motion.

## Additional changes
- Separate record and play functions as motion_manager to isolate from the teaching system using atomS3.
- Shorten display notations because of the variety of button presses.
- Change the location of stored json files from the execution directory to .ros/riberry