### PR TITLE
Add battery graph mode to atom_s3_i2c_display

### DIFF
--- a/firmware/atom_s3_i2c_display/README.md
+++ b/firmware/atom_s3_i2c_display/README.md
@@ -62,6 +62,7 @@ The `atom_s3_i2c_display` includes multiple modes. This feature allows the robot
 | servo_control_mode.cpp | servo_control_mode.py |
 | pressure_control_mode.cpp | pressure_control_mode.py |
 | teaching_mode.cpp | teaching_mode.py |
+| display_battery_graph_mode.cpp | display_battery_graph_mode.py |
 
 - `i2c_button_state_publisher.cpp` facilitates communication between these programs.
 The following sections provide details on the base code for the AtomS3 firmware.
@@ -112,3 +113,7 @@ The following sections provide details on the base code for the AtomS3 firmware.
     - After starting, a double click stops playing motion.
   - A triple click deletes the selected motion.
   - After playback or delete, the state automatically returns to `WAIT`.
+
+- Display Battery Graph Mode
+
+  Displays the remaining battery charge as a percentage, with a graph of the change over time underneath.

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
@@ -137,7 +137,7 @@ void AtomS3LCD::resetLcdData() {
   mode_changed = true;
 }
 
-void AtomS3LCD::setTextSize(int x) {
+void AtomS3LCD::setTextSize(float x) {
   lcd.setTextSize(x);
 }
 

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
@@ -136,3 +136,27 @@ void AtomS3LCD::resetLcdData() {
   resetQRcodeData();
   mode_changed = true;
 }
+
+void AtomS3LCD::setTextSize(int x) {
+  lcd.setTextSize(x);
+}
+
+void AtomS3LCD::fillRect(int x1, int y1, int w, int h, uint16_t color) {
+  lcd.fillRect(x1, y1, w, h, color);
+}
+
+void AtomS3LCD::drawLine(int x1, int y1, int x2, int y2, uint16_t color){
+  lcd.drawLine(x1, y1, x2, y2, color);
+};
+
+void AtomS3LCD::drawPixel(int x, int y, uint16_t color){
+  lcd.drawPixel(x, y, color);
+};
+
+void AtomS3LCD::setCursor(int x, int y){
+  lcd.setCursor(x,y);
+};
+
+uint16_t AtomS3LCD::color565(uint8_t red, uint8_t green, uint8_t blue){
+  return lcd.color565(red,green,blue);
+};

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
@@ -145,6 +145,10 @@ void AtomS3LCD::fillRect(int x1, int y1, int w, int h, uint16_t color) {
   lcd.fillRect(x1, y1, w, h, color);
 }
 
+void AtomS3LCD::drawRect(int x1, int y1, int w, int h, uint16_t color) {
+  lcd.drawRect(x1, y1, w, h, color);
+}
+
 void AtomS3LCD::drawLine(int x1, int y1, int x2, int y2, uint16_t color){
   lcd.drawLine(x1, y1, x2, y2, color);
 };

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -80,7 +80,7 @@ public:
   void resetJpegBuf();
   void resetQRcodeData();
   void resetLcdData();
-  void setTextSize(int x);
+  void setTextSize(float x);
   void fillRect(int x1, int y1, int x2, int y2, uint16_t color);
   void drawLine(int x1, int y1, int x2, int y2, uint16_t color);
   void drawPixel(int x, int y, uint16_t color);

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -5,6 +5,9 @@
 #include <LovyanGFX.hpp>
 #include <LGFX_AUTODETECT.hpp>
 
+#define LCD_W 128
+#define LCD_H 128
+
 /**
  * @brief Class to handle the LCD on the AtomS3 using the LovyanGFX library.
  */
@@ -77,6 +80,12 @@ public:
   void resetJpegBuf();
   void resetQRcodeData();
   void resetLcdData();
+  void setTextSize(int x);
+  void fillRect(int x1, int y1, int x2, int y2, uint16_t color);
+  void drawLine(int x1, int y1, int x2, int y2, uint16_t color);
+  void drawPixel(int x, int y, uint16_t color);
+  void setCursor(int x, int y);
+  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue);
 
   bool mode_changed = false;
 

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -82,6 +82,7 @@ public:
   void resetLcdData();
   void setTextSize(float x);
   void fillRect(int x1, int y1, int x2, int y2, uint16_t color);
+  void drawRect(int x1, int y1, int x2, int y2, uint16_t color);
   void drawLine(int x1, int y1, int x2, int y2, uint16_t color);
   void drawPixel(int x, int y, uint16_t color);
   void setCursor(int x, int y);

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
@@ -38,9 +38,11 @@ void DisplayBatteryGraphMode::task(void *parameter) {
           token = strtok(NULL, ",");
           index++;
         }
-        instance->updateGraph(percentages, index, duration);
+        if (index > 0) {
+          instance->updateGraph(percentages, index, duration);
+        }
       }
-      vTaskDelay(pdMS_TO_TICKS(1000));
+      vTaskDelay(pdMS_TO_TICKS(10000));
     }
   }
 }
@@ -78,7 +80,7 @@ void DisplayBatteryGraphMode::updateGraph(float* buffer, int buffer_length, int 
     }
   }
   // x label text
-  String x_label = "duration:" + String(duration);
+  String x_label = "duration:" + String(duration) + "[s]";
   instance->atoms3lcd.setCursor(LCD_W/2-x_label.length()*5/2, LCD_H-x_label_h);
   instance->atoms3lcd.printColorText(x_label);
   instance->atoms3lcd.setTextSize(1.5); // Restore default size for other modes

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
@@ -1,0 +1,98 @@
+#include <display_battery_graph_mode.h>
+
+DisplayBatteryGraphMode* DisplayBatteryGraphMode::instance = nullptr;
+
+DisplayBatteryGraphMode::DisplayBatteryGraphMode(AtomS3LCD &lcd, AtomS3I2C &i2c)
+  : atoms3lcd(lcd), atoms3i2c(i2c), Mode("DisplayBatteryGraphMode") {
+    instance = this;
+}
+
+void DisplayBatteryGraphMode::task(void *parameter) {
+  while (true) {
+    instance->atoms3i2c.setRequestStr(instance->getModeName());
+    // Check for I2C timeout
+    if (instance->atoms3i2c.checkTimeout()) {
+      instance->atoms3lcd.drawNoDataReceived();
+      instance->atoms3lcd.printMessage(instance->getModeName());
+      vTaskDelay(pdMS_TO_TICKS(500));
+      continue;
+    }
+    // Display information
+    else {
+      instance->atoms3lcd.drawBlack();
+      if (instance->atoms3lcd.color_str.isEmpty())
+        instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName());
+      else {
+        int index = 0;
+        // Split by comma
+        char* token = strtok(const_cast<char*>(instance->atoms3lcd.color_str.c_str()), ",");
+        int duration = 0;
+        if (token != NULL) {
+          duration = atoi(token); // Convert string to integer
+          token = strtok(NULL, ",");
+        }
+
+        float percentages[max_buffer_length]; // Receive less than 100 floats
+        while (token != NULL && index < max_buffer_length) {
+          percentages[index] = atof(token); // Convert string to float
+          token = strtok(NULL, ",");
+          index++;
+        }
+        instance->updateGraph(percentages, index, duration);
+      }
+      vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+  }
+}
+
+void DisplayBatteryGraphMode::createTask(uint8_t xCoreID) {
+  xTaskCreatePinnedToCore(task, "Display Battery Graph Mode", 2048, NULL, 1, &taskHandle, xCoreID);
+}
+
+void DisplayBatteryGraphMode::updateGraph(float* buffer, int buffer_length, int duration) {
+  int gap = 1; // width between bar to bar
+  int buffer_w = (graph_w - (buffer_length - 1) * gap) / buffer_length;
+
+  instance->atoms3lcd.drawBlack();
+  // top text
+  instance->atoms3lcd.setTextSize(2);
+  instance->atoms3lcd.printColorText("Bat " + String(buffer[buffer_length-1]) + "%");
+  // y label text
+  instance->atoms3lcd.setTextSize(1);
+  instance->atoms3lcd.setCursor(0, title_h);
+  instance->atoms3lcd.printColorText("100");
+  instance->atoms3lcd.setCursor(0, title_h + graph_h/2);
+  instance->atoms3lcd.printColorText(" 50");
+  instance->atoms3lcd.setCursor(0, title_h + graph_h);
+  instance->atoms3lcd.printColorText("  0");
+  // y axis line
+  instance->atoms3lcd.drawLine(y_label_w, title_h, y_label_w, LCD_H-(x_label_h+2)-1, 0xffff);
+  // bar graph
+  for (int i = 0; i < buffer_length; i++) {
+    if (buffer[i] == 0)
+      continue;
+    int scaled_percentage = buffer[i] * (graph_h-1) / 100;
+    for (int j = 0; j <= scaled_percentage; j++) {
+      uint16_t color = calculateColor(j * 100 / (graph_h-1));
+      instance->atoms3lcd.fillRect((y_label_w+y_line_w)+i*(buffer_w+gap), LCD_H-(x_label_h+2)-j-1, buffer_w, 1, color);
+    }
+  }
+  // x label text
+  String x_label = "duration:" + String(duration);
+  instance->atoms3lcd.setCursor(LCD_W/2-x_label.length()*5/2, LCD_H-x_label_h);
+  instance->atoms3lcd.printColorText(x_label);
+  instance->atoms3lcd.setTextSize(1.5); // Restore default size for other modes
+}
+
+// Gradation from red to yellow to green
+uint16_t DisplayBatteryGraphMode::calculateColor(float percentage) {
+  uint8_t red, green;
+  if (percentage <= 50.0f) {
+    red = 255;
+    green = (uint8_t)(percentage * 2.55 * 2);
+  } else {
+    red = (uint8_t)((100 - percentage) * 2.55 * 2);
+    green = 255;
+  }
+  return instance->atoms3lcd.color565(red, green, 0);
+}

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
@@ -19,10 +19,10 @@ void DisplayBatteryGraphMode::task(void *parameter) {
     }
     // Display information
     else {
-      instance->atoms3lcd.drawBlack();
-      if (instance->atoms3lcd.color_str.isEmpty())
+      if (instance->atoms3lcd.color_str.isEmpty()) {
+        instance->atoms3lcd.drawBlack();
         instance->atoms3lcd.printColorText("Waiting for " + instance->getModeName());
-      else {
+      }else {
         int index = 0;
         // Split by comma
         char* token = strtok(const_cast<char*>(instance->atoms3lcd.color_str.c_str()), ",");
@@ -54,7 +54,7 @@ void DisplayBatteryGraphMode::task(void *parameter) {
           instance->updateGraph(percentages, index, charge_status, charge_current, duration);
         }
       }
-      vTaskDelay(pdMS_TO_TICKS(10000));
+      vTaskDelay(pdMS_TO_TICKS(1000));
     }
   }
 }

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.h
@@ -1,0 +1,30 @@
+#ifndef ATOM_S3_DISPLAY_BATTERY_GRAPH_MODE_H
+#define ATOM_S3_DISPLAY_BATTERY_GRAPH_MODE_H
+
+#include <mode.h>
+#include <atom_s3_lcd.h>
+#include <atom_s3_i2c.h>
+
+class DisplayBatteryGraphMode : public Mode {
+public:
+  DisplayBatteryGraphMode(AtomS3LCD &lcd, AtomS3I2C &i2c);
+  void createTask(uint8_t xCoreID) override;
+
+private:
+  static const int32_t title_h = 20;
+  static const int32_t y_label_w = 18;
+  static const int32_t y_line_w = 1;
+  static const int32_t x_label_h = 8;
+  static const int32_t graph_h = LCD_H - title_h - x_label_h - 2; //98
+  static const int32_t graph_w = LCD_W - y_label_w - y_line_w; //109
+  static DisplayBatteryGraphMode* instance; /**< Singleton instance of DisplayBatteryGraphMode. */
+  static const int max_buffer_length = 100;
+  AtomS3LCD &atoms3lcd;
+  AtomS3I2C &atoms3i2c;
+
+  static void task(void *parameter);
+  void updateGraph(float* buffer, int buffer_length, int duration);
+  uint16_t calculateColor(float percentage);
+};
+
+#endif // DISPLAY_BATTERY_GRAPH_MODE_H

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.h
@@ -11,20 +11,21 @@ public:
   void createTask(uint8_t xCoreID) override;
 
 private:
-  static const int32_t title_h = 30;
+  static const int32_t title_h = 35;
   static const int32_t y_label_w = 18;
   static const int32_t y_line_w = 1;
   static const int32_t x_label_h = 8;
-  static const int32_t graph_h = LCD_H - title_h - x_label_h - 2; //98
+  static const int32_t graph_h = LCD_H - title_h - x_label_h - 2; //83
   static const int32_t graph_w = LCD_W - y_label_w - y_line_w; //109
-  static DisplayBatteryGraphMode* instance; /**< Singleton instance of DisplayBatteryGraphMode. */
+  static DisplayBatteryGraphMode* instance;
   static const int max_buffer_length = 100;
   AtomS3LCD &atoms3lcd;
   AtomS3I2C &atoms3i2c;
 
   static void task(void *parameter);
-  void updateGraph(float* buffer, int buffer_length, String status, int duration);
+  void updateGraph(float* buffer, int buffer_length, String status, String current, int duration);
   uint16_t calculateColor(float percentage);
+  void drawBatteryIcon(int x, int y, int width, int height, int batteryLevel);
 };
 
 #endif // DISPLAY_BATTERY_GRAPH_MODE_H

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.h
@@ -11,7 +11,7 @@ public:
   void createTask(uint8_t xCoreID) override;
 
 private:
-  static const int32_t title_h = 20;
+  static const int32_t title_h = 30;
   static const int32_t y_label_w = 18;
   static const int32_t y_line_w = 1;
   static const int32_t x_label_h = 8;
@@ -23,7 +23,7 @@ private:
   AtomS3I2C &atoms3i2c;
 
   static void task(void *parameter);
-  void updateGraph(float* buffer, int buffer_length, int duration);
+  void updateGraph(float* buffer, int buffer_length, String status, int duration);
   uint16_t calculateColor(float percentage);
 };
 

--- a/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
+++ b/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
@@ -12,14 +12,15 @@ class DisplayBatteryGraphMode(I2CBase):
         super().__init__(i2c_addr)
 
         self.mode = None
-        self.display_duration = 600 # Assume battery topic is 1Hz
+        self.display_duration = rospy.get_param("~display_duration", 3600)
+        # Assume battery topic is 1Hz
         self.display_bins = 10
         self.battery_percentages = [0] * self.display_duration
         rospy.Subscriber("/atom_s3_mode", String,
                          callback=self.mode_cb, queue_size=1)
         rospy.Subscriber("/battery/remaining_battery", Float32,
                          callback=self.battery_cb, queue_size=1)
-        rospy.Timer(rospy.Duration(1), self.timer_callback)
+        rospy.Timer(rospy.Duration(10), self.timer_callback)
 
     def mode_cb(self, msg):
         """

--- a/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
+++ b/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import rospy
+from std_msgs.msg import Float32
+from std_msgs.msg import String
+
+from riberry.i2c_base import I2CBase
+
+
+class DisplayBatteryGraphMode(I2CBase):
+    def __init__(self, i2c_addr,
+                 lock_path="/tmp/i2c_display_battery_graph_mode.lock"):
+        super().__init__(i2c_addr)
+
+        self.mode = None
+        self.display_duration = 600 # Assume battery topic is 1Hz
+        self.display_bins = 10
+        self.battery_percentages = [0] * self.display_duration
+        rospy.Subscriber("/atom_s3_mode", String,
+                         callback=self.mode_cb, queue_size=1)
+        rospy.Subscriber("/battery/remaining_battery", Float32,
+                         callback=self.battery_cb, queue_size=1)
+        rospy.Timer(rospy.Duration(1), self.timer_callback)
+
+    def mode_cb(self, msg):
+        """
+        Check AtomS3 mode.
+        """
+        self.mode = msg.data
+
+    def battery_cb(self, msg):
+        for i in range(self.display_duration-1):
+            self.battery_percentages[i] = self.battery_percentages[i+1]
+        self.battery_percentages[-1] = msg.data
+
+    def timer_callback(self, event):
+        if self.mode != "DisplayBatteryGraphMode":
+            return
+        sent_str = f'{self.display_duration},'
+        for i in range(self.display_bins):
+            percentage = self.battery_percentages[
+                int((i+1)*self.display_duration/self.display_bins)-1]
+            sent_str += f'{percentage}'
+            if i != self.display_bins-1:
+                sent_str += ','
+        self.send_string(sent_str)
+
+
+if __name__ == "__main__":
+    rospy.init_node("display_battery_graph_mode")
+    dbgm = DisplayBatteryGraphMode(0x42)
+    rospy.spin()

--- a/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
+++ b/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
@@ -32,7 +32,12 @@ class DisplayBatteryGraphMode(I2CBase):
         """
         Check AtomS3 mode.
         """
+        previous_mode = self.mode
         self.mode = msg.data
+        if self.mode == "DisplayBatteryGraphMode":
+            if previous_mode != self.mode:
+                rospy.loginfo('start display battery graph mode')
+                self.send_data()
 
     def battery_cb(self, msg):
         for i in range(self.display_duration-1):
@@ -40,7 +45,10 @@ class DisplayBatteryGraphMode(I2CBase):
         self.battery_percentages[-1] = msg.data
 
     def status_cb(self, msg):
+        previous_status = self.charge_status
         self.charge_status = msg.data
+        if previous_status != self.charge_status:
+            self.send_data()
 
     def current_cb(self, msg):
         self.charge_current = int(msg.data)
@@ -48,6 +56,9 @@ class DisplayBatteryGraphMode(I2CBase):
     def timer_callback(self, event):
         if self.mode != "DisplayBatteryGraphMode":
             return
+        self.send_data()
+
+    def send_data(self):
         sent_str = f'{self.charge_status},{self.charge_current},{self.display_duration},'
         for i in range(self.display_bins):
             percentage = self.battery_percentages[


### PR DESCRIPTION
This mode displays a graph showing changes in the battery charge from `/battery/remaining_battery` topic. It also displays the current percentage and charge status in text.
The screen is updated once every 10 seconds, and the duration of the display can be specified in `display_duration` rosparam.

https://github.com/user-attachments/assets/134300b6-9660-444f-adc5-e6484158ce7b