### PR TITLE
radxa select the mode of use

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/atom_s3_button/atom_s3_button.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_button/atom_s3_button.cpp
@@ -3,7 +3,6 @@
 AtomS3Button::AtomS3Button(int pin, bool activeLow, bool pullupActive)
   : btn(pin, activeLow, pullupActive), currentButtonState(RESET), clicked(false), doubleClicked(false), longPressed(false) {
   begin();
-  createTask(0);
 }
 
 void AtomS3Button::begin() {

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.cpp
@@ -38,7 +38,7 @@ int AtomS3I2C::splitString(const String &input, char delimiter, String output[],
   return index; // 分割された部分の数を返す
 }
 
-// Receive data over I2C and store it in the atoms3lcd instance (color_str, jpegBuf, qrCodeData)
+// Receive data over I2C and store it in the atoms3lcd instance
 // No rendering is done; lcd update is handled by other tasks
 void AtomS3I2C::receiveEvent(int howMany) {
     if (instance->receiveEventEnabled == false)
@@ -49,51 +49,98 @@ void AtomS3I2C::receiveEvent(int howMany) {
     String str;
     // Read data from the I2C bus
     while (0 < WireSlave.available()) {
-        char c = WireSlave.read();  // receive byte as a character
-        // If currently loading JPEG, store the data in jpegBuf
-        if (instance->atoms3lcd.loadingJpeg && str.length() >= 3) {
-            instance->atoms3lcd.jpegBuf[instance->atoms3lcd.currentJpegIndex + str.length() - 3] = c;
-        }
+        char c = WireSlave.read();  // receive byte as a character;
         str += c;
     }
-    // Check for JPEG packet header and update length if found
-    if (instance->atoms3lcd.readyJpeg == false
-        && str.length() == 5 && (str[0] == jpegPacketHeader[0]) && (str[1] == jpegPacketHeader[1]) && (str[2] == jpegPacketHeader[2])) {
-        instance->atoms3lcd.jpegLength = (uint32_t)(str[3] << 8) | str[4];
+
+    // Parse the first byte as PacketType
+    if (str.length() < 1) {
+        return;  // Invalid packet
+    }
+
+    PacketType packetType = static_cast<PacketType>(str[0]);
+    switch (packetType) {
+        case JPEG:
+            handleJpegPacket(str.substring(1));
+            break;
+
+        case QR_CODE:
+            handleQrCodePacket(str);
+            break;
+
+        case FORCE_MODE:
+            handleForceModePacket(str);
+            break;
+
+        case SELECTED_MODE:
+            handleSelectedModePacket(str);
+            break;
+
+        case DISPLAY_BATTERY_GRAPH_MODE:
+            instance->atoms3lcd.color_str = str.substring(1); // remove PacketType Header
+            break;
+
+        case SERVO_CONTROL_MODE:
+            instance->atoms3lcd.color_str = str.substring(1); // remove PacketType Header
+            break;
+
+        case PRESSURE_CONTROL_MODE:
+            instance->atoms3lcd.color_str = str.substring(1); // remove PacketType Header
+            break;
+
+        case TEACHING_MODE:
+            instance->atoms3lcd.color_str = str.substring(1); // remove PacketType Header
+            break;
+
+        default:
+            // Handle TEXT or unknown packets
+            instance->atoms3lcd.color_str = str;
+            break;
+    }
+}
+
+void AtomS3I2C::handleJpegPacket(const String& str) {
+    if (str.length() == 2 && !instance->atoms3lcd.readyJpeg) {
+        // Initialize JPEG loading
+        instance->atoms3lcd.jpegLength = (static_cast<uint32_t>(str[0]) << 8) | static_cast<uint8_t>(str[1]);
         instance->atoms3lcd.currentJpegIndex = 0;
         instance->atoms3lcd.loadingJpeg = true;
-        return;
-    }
-    // Continue receiving JPEG data if already in loading state
-    else if (instance->atoms3lcd.loadingJpeg) {
-        if ((str[0] == jpegPacketHeader[0]) && (str[1] == jpegPacketHeader[1]) && (str[2] == jpegPacketHeader[2])) {
-            instance->atoms3lcd.currentJpegIndex += str.length() - 3;
-            // End loading if the entire JPEG is received
-            if (instance->atoms3lcd.currentJpegIndex >= instance->atoms3lcd.jpegLength) {
-                instance->atoms3lcd.loadingJpeg = false;
-                instance->atoms3lcd.readyJpeg = true;
-            }
-            return;
+    } else if (instance->atoms3lcd.loadingJpeg) {
+        size_t index = instance->atoms3lcd.currentJpegIndex;
+        size_t strLength = str.length();
+        // Continue loading JPEG data
+        if (index + strLength <= sizeof(instance->atoms3lcd.jpegBuf)) {
+          memcpy(instance->atoms3lcd.jpegBuf + index, str.c_str(), strLength);
+            instance->atoms3lcd.currentJpegIndex += strLength;
         } else {
-          // Stop loading if a wrong packet is received
-          instance->atoms3lcd.loadingJpeg = false;
+            instance->atoms3lcd.loadingJpeg = false;
         }
+        if (instance->atoms3lcd.currentJpegIndex >= instance->atoms3lcd.jpegLength) {
+            instance->atoms3lcd.loadingJpeg = false;
+            instance->atoms3lcd.readyJpeg = true;
+        }
+    } else {
+        instance->atoms3lcd.loadingJpeg = false;  // Reset if invalid packet received
     }
-    // Check for QR code header and store data if found
-    if (str.length() > 1 && str[0] == qrCodeHeader) {
-        uint8_t qrCodeLength = str[1];  // Assuming the length of the QR code data is in the second byte
+}
+
+void AtomS3I2C::handleQrCodePacket(const String& str) {
+    if (str.length() > 1) {
+        uint8_t qrCodeLength = static_cast<uint8_t>(str[1]);
         instance->atoms3lcd.qrCodeData = str.substring(2, 2 + qrCodeLength);
-        return;
     }
-    // Check for force mode change
-    if (str.length() > 1 && str[0] == forceModeHeader[0] && str[1] == forceModeHeader[1] && str[2] == forceModeHeader[2]) {
-      forcedMode = str.substring(3);
+}
+
+void AtomS3I2C::handleForceModePacket(const String& str) {
+    if (str.length() > 1) {
+        forcedMode = str.substring(1);
     }
-    // Check for selected modes
-    if (str.length() > 1 && str[0] == selectedModesHeader[0] && str[1] == selectedModesHeader[1] && str[2] == selectedModesHeader[2]) {
-      selectedModesStr = str.substring(3);
+}
+
+void AtomS3I2C::handleSelectedModePacket(const String& str) {
+    if (str.length() > 1) {
+        selectedModesStr = str.substring(1);
     }
-    instance->atoms3lcd.color_str = str;
 }
 
 void AtomS3I2C::stopReceiveEvent() {

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.h
@@ -33,6 +33,8 @@ public:
    */
   bool checkTimeout();
 
+  int splitString(const String &input, char delimiter, String output[], int maxParts);
+  
   void stopReceiveEvent();
   void startReceiveEvent();
   static void setRequestStr(const String &str);
@@ -52,6 +54,7 @@ public:
 #endif
 
   static String forcedMode;
+  static String selectedModesStr;
 
 private:
   bool receiveEventEnabled;
@@ -64,6 +67,7 @@ private:
   static constexpr uint8_t jpegPacketHeader[3] = { 0xFF, 0xD8, 0xEA }; /**< JPEG image packet header identifier. */
   static constexpr uint8_t qrCodeHeader = 0x02; /**< QR code packet header identifier. */
   static constexpr uint8_t forceModeHeader[3] = { 0xFF, 0xFE, 0xFD }; /**< Force mode packet header identifier. */
+  static constexpr uint8_t selectedModesHeader[3] = { 0xFC, 0xFB, 0xFA }; /**< Selected modes packet header identifier. */
 
   static String requestStr; /**< String to be sent on I2C request. */
 

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.h
@@ -6,6 +6,8 @@
 #include <atom_s3_lcd.h>
 #include <atom_s3_button.h>
 
+#include "packet.h"
+
 /**
  * @brief Handles I2C communication for AtomS3, including receiving and sending data via I2C bus.
  */
@@ -82,6 +84,10 @@ private:
    * @param howMany Number of bytes received.
    */
   static void receiveEvent(int howMany);
+  static void handleJpegPacket(const String& str);
+  static void handleQrCodePacket(const String& str);
+  static void handleForceModePacket(const String& str);
+  static void handleSelectedModePacket(const String& str);
 
   /**
    * @brief Called when the master requests data from the I2C slave.

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/packet.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/packet.h
@@ -1,0 +1,11 @@
+enum PacketType : uint8_t {
+    TEXT = 0x00,
+    JPEG = 0x01,
+    QR_CODE = 0x02,
+    FORCE_MODE = 0x03,
+    SELECTED_MODE = 0x04,
+    DISPLAY_BATTERY_GRAPH_MODE = 0x05,
+    SERVO_CONTROL_MODE = 0x06,
+    PRESSURE_CONTROL_MODE = 0x07,
+    TEACHING_MODE = 0x08,
+};

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_mode_manager/atom_s3_mode_manager.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_mode_manager/atom_s3_mode_manager.cpp
@@ -2,14 +2,16 @@
 
 AtomS3ModeManager* AtomS3ModeManager::instance = nullptr;
 
-std::vector<Mode*> AtomS3ModeManager::allModes = {};
+std::vector<Mode*> AtomS3ModeManager::selectedModes = {};
+String AtomS3ModeManager::selectedModesStr = "";
 int AtomS3ModeManager::current_mode_index = 0;
+const std::vector<Mode*>* AtomS3ModeManager::allModes = nullptr;
 
-AtomS3ModeManager::AtomS3ModeManager(AtomS3LCD &lcd, AtomS3Button &button, AtomS3I2C &i2c)
+AtomS3ModeManager::AtomS3ModeManager(AtomS3LCD &lcd, AtomS3Button &button, AtomS3I2C &i2c, const std::vector<Mode *> &modes)
   : atoms3lcd(lcd), atoms3button(button), atoms3i2c(i2c)
 {
   instance = this;
-  createTask(0);
+  allModes = &modes;
 }
 
 void AtomS3ModeManager::task(void *parameter) {
@@ -17,13 +19,40 @@ void AtomS3ModeManager::task(void *parameter) {
     return;
   }
 
-  instance->atoms3lcd.printWaitMessage(instance->atoms3i2c.i2c_slave_addr);
   while (true) {
+    // Check if selected Modes are changed
+    if (!selectedModesStr.equals(instance->atoms3i2c.selectedModesStr)) {
+      // Delete all modes
+      instance->deleteSelectedModes();
+      // Add selected modes
+      selectedModesStr = instance->atoms3i2c.selectedModesStr;
+      String* selectedModesStrList = new String[allModes->size()];
+      int modeCount = instance->atoms3i2c.splitString(selectedModesStr, ',', selectedModesStrList, allModes->size());
+      for (int i = 0; i < modeCount; i++) {
+        for (Mode *mode : *allModes) {
+          if (mode->getModeName().equals(selectedModesStrList[i])) {
+            instance->addSelectedMode(*mode); // ポインタから参照に変換
+          }
+        }
+      }
+      delete[] selectedModesStrList;
+      // Start task
+      current_mode_index = 0;
+      instance->initializeSelectedModes();
+      instance->startCurrentMode();
+    }
+    // If no mode is added, do nothing
+    if (selectedModes.size() == 0) {
+      instance->atoms3lcd.drawBlack();
+      instance->atoms3lcd.printMessage("Waiting for modes to be added...");
+      vTaskDelay(pdMS_TO_TICKS(500));
+      continue;
+    }
     // Check if Mode is forced to change
     bool isModeForced = false;
     int forced_mode_index;
-    for (int i = 0; i < allModes.size(); i++) {
-      if (allModes[i]->getModeName() == instance->atoms3i2c.forcedMode) {
+    for (int i = 0; i < selectedModes.size(); i++) {
+      if (selectedModes[i]->getModeName().equals(instance->atoms3i2c.forcedMode)) {
         isModeForced = true;
         forced_mode_index = i;
         break;
@@ -37,7 +66,7 @@ void AtomS3ModeManager::task(void *parameter) {
     }
     // Change mode by long click
     if (instance->atoms3button.wasLongPressed()) {
-      int next_mode_index = (current_mode_index + 1) % allModes.size();
+      int next_mode_index = (current_mode_index + 1) % selectedModes.size();
       instance->changeMode(current_mode_index, next_mode_index);
       current_mode_index = next_mode_index;
     }
@@ -49,35 +78,61 @@ void AtomS3ModeManager::createTask(uint8_t xCoreID) {
   xTaskCreatePinnedToCore(task, "Mode Manager Task", 2048, this, 24, NULL, xCoreID);
 }
 
-void AtomS3ModeManager::initializeAllModes(uint8_t xCoreID) {
+void AtomS3ModeManager::initializeSelectedModes() {
   // Start user-defined mode
-  for (int i = 0; i < allModes.size(); i++) {
-    if (!allModes[i]->isTaskCreated()) {
-      allModes[i]->createTask(xCoreID);
+  uint8_t xCoreID = 1;
+  for (int i = 0; i < selectedModes.size(); i++) {
+    if (!selectedModes[i]->isTaskCreated()) {
+      selectedModes[i]->createTask(xCoreID);
     }
-    allModes[i]->suspendTask();
+    selectedModes[i]->suspendTask();
   }
 }
 
 void AtomS3ModeManager::startCurrentMode() {
-  allModes[current_mode_index]->resumeTask();
+  if (selectedModes.size() == 0)
+    return;
+  selectedModes[current_mode_index]->resumeTask();
+}
+
+void AtomS3ModeManager::stopCurrentMode() {
+  if (selectedModes.size() == 0)
+    return;
+  selectedModes[current_mode_index]->suspendTask();
+}
+
+bool AtomS3ModeManager::isValidIndex(const std::vector<Mode*>& vec, int index) {
+  // index が 0 以上 vec.size() 未満であれば true を返す
+  return index >= 0 && index < static_cast<int>(vec.size());
 }
 
 void AtomS3ModeManager::changeMode(int suspend_mode_index, int resume_mode_index) {
-    // Suspend
-    allModes[suspend_mode_index]->suspendTask();
-    // Transition
-    allModes[suspend_mode_index]->waitForTaskSuspended();
-    instance->atoms3i2c.stopReceiveEvent();
-    instance->atoms3lcd.drawBlack();
-    instance->atoms3lcd.printMessage("Wait for mode switch ...");
-    vTaskDelay(pdMS_TO_TICKS(1000));
-    instance->atoms3lcd.resetLcdData();
-    // Resume
-    allModes[resume_mode_index]->resumeTask();
-    instance->atoms3i2c.startReceiveEvent();
+  if (!isValidIndex(selectedModes, suspend_mode_index) || !isValidIndex(selectedModes, resume_mode_index))
+      return;
+  // Suspend
+  selectedModes[suspend_mode_index]->suspendTask();
+  // Transition
+  selectedModes[suspend_mode_index]->waitForTaskSuspended();
+  instance->atoms3i2c.stopReceiveEvent();
+  instance->atoms3lcd.drawBlack();
+  instance->atoms3lcd.printMessage("Wait for mode switch ...");
+  vTaskDelay(pdMS_TO_TICKS(1000));
+  instance->atoms3lcd.resetLcdData();
+  // Resume
+  selectedModes[resume_mode_index]->resumeTask();
+  instance->atoms3i2c.startReceiveEvent();
 }
 
-void AtomS3ModeManager::addMode(Mode &mode) {
-  allModes.push_back(&mode);
+void AtomS3ModeManager::addSelectedMode(Mode &mode) {
+  selectedModes.push_back(&mode);
+}
+
+void AtomS3ModeManager::deleteSelectedModes() {
+  // Before deleting modes, all modes must be suspended
+  for (int i = 0; i < selectedModes.size(); i++) {
+    if (!selectedModes[i]->isTaskSuspended()) {
+      selectedModes[i]->suspendTask();
+    }
+  }
+  selectedModes.clear();
 }

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_mode_manager/atom_s3_mode_manager.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_mode_manager/atom_s3_mode_manager.h
@@ -11,11 +11,11 @@
 
 class AtomS3ModeManager {
 public:
-  AtomS3ModeManager(AtomS3LCD &lcd, AtomS3Button &button, AtomS3I2C &i2c);
+  AtomS3ModeManager(AtomS3LCD &lcd, AtomS3Button &button, AtomS3I2C &i2c, const std::vector<Mode *> &modes);
   void createTask(uint8_t xCoreID);
-  void initializeAllModes(uint8_t xCoreID);
+  void initializeSelectedModes();
   void startCurrentMode();
-  void addMode(Mode &mode);
+  void addSelectedMode(Mode &mode);
 
 private:
   static AtomS3ModeManager* instance; /**< Singleton instance of AtomS3ModeManager. */
@@ -24,11 +24,16 @@ private:
   AtomS3LCD &atoms3lcd;
   AtomS3I2C &atoms3i2c;
 
-  static std::vector<Mode*> allModes;
+  static const std::vector<Mode*> *allModes;
+  static std::vector<Mode*> selectedModes;
+  static String selectedModesStr;
   static int current_mode_index;
 
   static void task(void *parameter);
+  bool isValidIndex(const std::vector<Mode*>& vec, int index);
   void changeMode(int suspend_mode_index, int resume_mode_index);
+  void stopCurrentMode();
+  void deleteSelectedModes();
 };
 
 #endif

--- a/firmware/atom_s3_i2c_display/lib/mode/mode.h
+++ b/firmware/atom_s3_i2c_display/lib/mode/mode.h
@@ -30,15 +30,15 @@ public:
     }
   }
 
-  bool isTaskSuspended() {
+  bool isTaskSuspended() const {
     return eTaskGetState(taskHandle) == eSuspended;
   }
 
-  bool isTaskCreated() {
+  bool isTaskCreated() const {
     return taskHandle != NULL;
   }
 
-  void waitForTaskSuspended() {
+  void waitForTaskSuspended() const {
     while (!isTaskSuspended()) {
       vTaskDelay(pdMS_TO_TICKS(100));
     }

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -2,28 +2,43 @@
 #include <atom_s3_i2c.h>
 #include <atom_s3_button.h>
 
-#include <atom_s3_mode_manager.h>
 #include <display_information_mode.h>
 #include <display_qrcode_mode.h>
 #include <display_image_mode.h>
+#include <display_battery_graph_mode.h>
+#include <servo_control_mode.h>
+#include <pressure_control_mode.h>
+#include <teaching_mode.h>
+
+#include <atom_s3_mode_manager.h>
 
 AtomS3Button atoms3button;
 AtomS3LCD atoms3lcd;
 AtomS3I2C atoms3i2c(atoms3lcd, atoms3button);
-AtomS3ModeManager atoms3modemanager(atoms3lcd, atoms3button, atoms3i2c);
 
+// Define all available modes
 DisplayInformationMode display_information_mode(atoms3lcd, atoms3i2c);
 DisplayQRcodeMode display_qrcode_mode(atoms3lcd, atoms3i2c);
 DisplayImageMode display_image_mode(atoms3lcd, atoms3i2c);
+DisplayBatteryGraphMode display_battery_graph_mode(atoms3lcd, atoms3i2c);
+ServoControlMode servo_control_mode(atoms3lcd, atoms3i2c);
+PressureControlMode pressure_control_mode(atoms3lcd, atoms3i2c);
+TeachingMode teaching_mode(atoms3lcd, atoms3i2c);
+const std::vector<Mode*> allModes =
+  {&display_information_mode, &display_qrcode_mode, &display_image_mode, &display_battery_graph_mode,
+   &servo_control_mode, &pressure_control_mode, &teaching_mode,
+  };
+
+AtomS3ModeManager atoms3modemanager(atoms3lcd, atoms3button, atoms3i2c, allModes);
 
 void setup() {
-  atoms3modemanager.addMode(display_information_mode);
-  atoms3modemanager.addMode(display_qrcode_mode);
-  atoms3modemanager.addMode(display_image_mode);
-
-  // Start one of the user-defined modes
-  uint8_t eachModeCoreID = 1;
-  atoms3modemanager.initializeAllModes(eachModeCoreID);
+  atoms3button.createTask(0);
+  atoms3i2c.createTask(0);
+  atoms3modemanager.createTask(0);
+  // By default, DisplayInformationMode and DisplayQRcodeMode are added
+  atoms3modemanager.addSelectedMode(display_information_mode);
+  atoms3modemanager.addSelectedMode(display_qrcode_mode);
+  atoms3modemanager.initializeSelectedModes();
   atoms3modemanager.startCurrentMode();
 }
 

--- a/riberry/i2c_base.py
+++ b/riberry/i2c_base.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 import fcntl
 import sys
 
@@ -114,3 +115,15 @@ class I2CBase:
             return "Unknown Device"
         except FileNotFoundError:
             return "Unknown Device"
+
+
+class PacketType(IntEnum):
+    TEXT = 0x00
+    JPEG = 0x01
+    QR_CODE = 0x02
+    FORCE_MODE = 0x03
+    SELECTED_MODE = 0x04
+    DISPLAY_BATTERY_GRAPH_MODE = 0x05
+    SERVO_CONTROL_MODE = 0x06
+    PRESSURE_CONTROL_MODE = 0x07
+    TEACHING_MODE = 0x08

--- a/ros/riberry_startup/launch/all_modes.launch
+++ b/ros/riberry_startup/launch/all_modes.launch
@@ -1,0 +1,47 @@
+<launch>
+
+  <!-- Usage -->
+  <!-- Comment out all nodes and mode_names params except the one you want to use -->
+
+  <node name="set_mode"
+        pkg="riberry_startup" type="set_mode.py"
+        output="screen"
+        respawn="true">
+    <rosparam>
+      <!-- The order of the mode_names is the order of the AtomS3 screen -->
+      mode_names:
+      - DisplayInformationMode <!-- Enabled by display_information.service -->
+      - DisplayQRcodeMode <!-- Enabled by display_information.service -->
+      - DisplayImageMode <!-- Enabled by display_information.service -->
+      - DisplayBatteryGraphMode
+      - ServoControlMode
+      - PressureControlMode
+      - TeachingMode
+    </rosparam>
+  </node>
+
+  <node name="display_battery_graph_mode"
+        pkg="riberry_startup" type="display_battery_graph_mode.py"
+        output="screen"
+        respawn="true">
+  </node>
+
+  <node name="servo_control_mode"
+        pkg="riberry_startup" type="servo_control_mode.py"
+        output="screen"
+        respawn="true">
+  </node>
+
+  <node name="pressure_control_mode"
+        pkg="riberry_startup" type="pressure_control_mode.py"
+        output="screen"
+        respawn="true">
+  </node>
+
+  <node name="teaching_mode"
+        pkg="riberry_startup" type="teaching_mode.py"
+        output="screen"
+        respawn="true">
+  </node>
+
+</launch>

--- a/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
+++ b/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
@@ -4,11 +4,11 @@ from std_msgs.msg import Float32
 from std_msgs.msg import String
 
 from riberry.i2c_base import I2CBase
+from riberry.i2c_base import PacketType
 
 
 class DisplayBatteryGraphMode(I2CBase):
-    def __init__(self, i2c_addr,
-                 lock_path="/tmp/i2c_display_battery_graph_mode.lock"):
+    def __init__(self, i2c_addr):
         super().__init__(i2c_addr)
 
         self.mode = None
@@ -60,7 +60,8 @@ class DisplayBatteryGraphMode(I2CBase):
         self.send_data()
 
     def send_data(self):
-        sent_str = f'{self.charge_status},{self.charge_current},{self.display_duration},'
+        sent_str = [chr(PacketType.DISPLAY_BATTERY_GRAPH_MODE)]
+        sent_str += f'{self.charge_status},{self.charge_current},{self.display_duration},'
         for i in range(self.display_bins):
             percentage = self.battery_percentages[
                 int((i+1)*self.display_duration/self.display_bins)-1]

--- a/ros/riberry_startup/node_scripts/pressure_control_mode.py
+++ b/ros/riberry_startup/node_scripts/pressure_control_mode.py
@@ -9,10 +9,11 @@ from std_msgs.msg import Int32
 from std_msgs.msg import String
 
 from riberry.i2c_base import I2CBase
+from riberry.i2c_base import PacketType
 
 
 class PressureControlMode(I2CBase):
-    def __init__(self, i2c_addr, lock_path="/tmp/i2c_pressure_control_mode.lock"):
+    def __init__(self, i2c_addr):
         super().__init__(i2c_addr)
         # Create robot model to control pressure
         robot_model = RobotModel()
@@ -100,7 +101,8 @@ class PressureControlMode(I2CBase):
     def timer_callback(self, event):
         if self.mode != "PressureControlMode":
             return
-        sent_str = "pressure [kPa]\n"
+        sent_str = chr(PacketType.PRESSURE_CONTROL_MODE)
+        sent_str += "pressure [kPa]\n"
         for idx, value in self.pressures.items():
             if value is None:
                 continue

--- a/ros/riberry_startup/node_scripts/servo_control_mode.py
+++ b/ros/riberry_startup/node_scripts/servo_control_mode.py
@@ -8,10 +8,11 @@ from std_msgs.msg import Int32
 from std_msgs.msg import String
 
 from riberry.i2c_base import I2CBase
+from riberry.i2c_base import PacketType
 
 
 class ServoControlMode(I2CBase):
-    def __init__(self, i2c_addr, lock_path="/tmp/i2c_servo_control_mode.lock"):
+    def __init__(self, i2c_addr):
         super().__init__(i2c_addr)
         # Create robot model to control servo
         robot_model = RobotModel()
@@ -80,7 +81,8 @@ class ServoControlMode(I2CBase):
         if self.mode != "ServoControlMode":
             return
         # Send message on AtomS3 LCD
-        sent_str = "Servo control mode\n\nSingle Click:\nServo on off"
+        sent_str = chr(PacketType.SERVO_CONTROL_MODE)
+        sent_str += "Servo control mode\n\nSingle Click:\nServo on off"
         self.send_string(sent_str)
 
 

--- a/ros/riberry_startup/node_scripts/set_mode.py
+++ b/ros/riberry_startup/node_scripts/set_mode.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import rospy
+
+from riberry.i2c_base import I2CBase
+
+
+class SetMode(I2CBase):
+    def __init__(self, i2c_addr):
+        super().__init__(i2c_addr)
+        self.mode_names = self.get_mode_names_from_rosparam()
+        rospy.Timer(rospy.Duration(1), self.timer_callback)
+
+    def get_mode_names_from_rosparam(self):
+        try:
+            mode_name_list = rospy.get_param("~mode_names", "")
+            return ",".join(mode_name_list)
+        except KeyError:
+            rospy.logwarn("rosparam 'mode_names' が見つかりませんでした。空のリストを設定します。")
+            return ""
+
+    def timer_callback(self, event):
+        header = [0xFC, 0xFB, 0xFA]
+        forceModebytes = (list (map(ord, self.mode_names)))
+        rospy.loginfo_throttle(60, f"Mode names: {self.mode_names}")
+        self.send_raw_bytes(header + forceModebytes)
+
+
+if __name__ == "__main__":
+    rospy.init_node("set_mode")
+    SetMode(0x42)
+    rospy.spin()

--- a/ros/riberry_startup/node_scripts/set_mode.py
+++ b/ros/riberry_startup/node_scripts/set_mode.py
@@ -3,6 +3,7 @@
 import rospy
 
 from riberry.i2c_base import I2CBase
+from riberry.i2c_base import PacketType
 
 
 class SetMode(I2CBase):
@@ -20,7 +21,7 @@ class SetMode(I2CBase):
             return ""
 
     def timer_callback(self, event):
-        header = [0xFC, 0xFB, 0xFA]
+        header = [PacketType.SELECTED_MODE]
         forceModebytes = (list (map(ord, self.mode_names)))
         rospy.loginfo_throttle(60, f"Mode names: {self.mode_names}")
         self.send_raw_bytes(header + forceModebytes)

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -9,6 +9,7 @@ from std_msgs.msg import Int32
 from std_msgs.msg import String
 
 from riberry.i2c_base import I2CBase
+from riberry.i2c_base import PacketType
 from riberry.motion_manager import MotionManager
 from riberry.select_list import SelectList
 
@@ -20,7 +21,7 @@ class State(Enum):
 
 
 class TeachingMode(I2CBase):
-    def __init__(self, i2c_addr, lock_path="/tmp/teaching_mode.lock"):
+    def __init__(self, i2c_addr):
         super().__init__(i2c_addr)
         self.motion_manager = MotionManager()
         self.json_dir = os.path.join(os.environ["HOME"], ".ros/riberry")
@@ -98,7 +99,7 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
     def timer_callback(self, event):
         if self.mode != "TeachingMode":
             return
-        sent_str = ''
+        sent_str = chr(PacketType.TEACHING_MODE)
         if self.state == State.WAIT:
             sent_str += 'Teaching mode\n\n'\
                 + '1tap:\n record\n\n'\


### PR DESCRIPTION
#### Usage

- Define all modes in AtomS3.
- Set which mode to use in rosparam, and radxa will tell AtomS3 which mode to use.

#### Sample

```
<launch>
  <node name="set_mode"
        pkg="riberry_startup" type="set_mode.py" 
        output="screen"
        respawn="true">
    <rosparam>
      mode_names:
      - DisplayInformationMode
      - DisplayQRcodeMode
      - DisplayBatteryGraphMode
    </rosparam>
  </node>
</launch>
```