### PR TITLE
Add lcdMutex

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_i2c/atom_s3_i2c.cpp
@@ -189,7 +189,7 @@ void AtomS3I2C::setRequestStr(const String &str) {
 void AtomS3I2C::task(void *parameter) {
   bool success = WireSlave.begin(sda_pin, scl_pin, i2c_slave_addr, 200, 100);
   if (!success) {
-    instance->atoms3lcd.printMessage("I2C slave init failed");
+    instance->atoms3lcd.printColorText("I2C slave init failed\n");
     while (1) vTaskDelay(pdMS_TO_TICKS(100));;
   }
   // Ensure the program starts in a timeout state

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
@@ -16,10 +16,6 @@ void AtomS3LCD::clear() {
     lcd.clear();
 }
 
-void AtomS3LCD::printMessage(const String& message) {
-    lcd.println(message);
-}
-
 uint16_t AtomS3LCD::colorMap(int code, bool isBackground) {
     if (isBackground) {
         switch (code) {
@@ -78,7 +74,7 @@ void AtomS3LCD::printColorText(const String& input) {
 }
 
 void AtomS3LCD::printWaitMessage(int i2cAddress) {
-    printMessage("Wait for I2C input.");
+    printColorText("Wait for I2C input.\n");
 #ifdef USE_GROVE
     printColorText("\x1b[31mGROVE\x1b[39m Mode\n");
 #else

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.cpp
@@ -1,117 +1,51 @@
 #include <atom_s3_lcd.h>
 
 AtomS3LCD::AtomS3LCD()
-  : lcd(), qrCodeData("") {
-  init();
-}
-
-void AtomS3LCD::init() {
-    lcd.init();
-    lcd.setRotation(lcd_rotation);
-    lcd.clear();
-    lcd.setTextSize(1.5);
-}
-
-void AtomS3LCD::clear() {
-    lcd.clear();
-}
-
-uint16_t AtomS3LCD::colorMap(int code, bool isBackground) {
-    if (isBackground) {
-        switch (code) {
-        case 40: return lcd.color565(0, 0, 0);     // Black
-        case 41: return lcd.color565(255, 0, 0);   // Red
-        case 42: return lcd.color565(0, 255, 0);   // Green
-        case 43: return lcd.color565(255, 255, 0); // Yellow
-        case 44: return lcd.color565(0, 0, 255);   // Blue
-        case 45: return lcd.color565(255, 0, 255); // Magenta
-        case 46: return lcd.color565(0, 255, 255); // Cyan
-        case 47: return lcd.color565(255, 255, 255); // White
-        case 49: return lcd.color565(0, 0, 0);     // Default (Black)
-        default: return lcd.color565(0, 0, 0);
-        }
-    } else {
-        switch (code) {
-        case 30: return lcd.color565(0, 0, 0);     // Black
-        case 31: return lcd.color565(255, 0, 0);   // Red
-        case 32: return lcd.color565(0, 255, 0);   // Green
-        case 33: return lcd.color565(255, 255, 0); // Yellow
-        case 34: return lcd.color565(0, 0, 255);   // Blue
-        case 35: return lcd.color565(255, 0, 255); // Magenta
-        case 36: return lcd.color565(0, 255, 255); // Cyan
-        case 37: return lcd.color565(255, 255, 255); // White
-        case 39: return lcd.color565(255, 255, 255); // Default (White)
-        default: return lcd.color565(255, 255, 255);
-        }
-    }
-}
-
-void AtomS3LCD::printColorText(const String& input) {
-    String text = input;
-    uint16_t textColor = lcd.color565(255, 255, 255); // Default text color: white
-    uint16_t bgColor = lcd.color565(0, 0, 0);         // Default background color: black
-    int index = 0;
-
-    while (index < text.length()) {
-        if (text.charAt(index) == '\x1b' && text.charAt(index + 1) == '[') {
-            int mIndex = text.indexOf('m', index);
-            if (mIndex != -1) {
-                String seq = text.substring(index + 2, mIndex);
-                int code = seq.toInt();
-                if (seq.startsWith("4")) {
-                    bgColor = colorMap(code, true);
-                } else if (seq.startsWith("3")) {
-                    textColor = colorMap(code, false);
-                }
-                text.remove(index, mIndex - index + 1);
-                continue;
-            }
-        }
-        lcd.setTextColor(textColor, bgColor);
-        lcd.print(text.charAt(index));
-        index++;
-    }
-}
-
-void AtomS3LCD::printWaitMessage(int i2cAddress) {
-    printColorText("Wait for I2C input.\n");
-#ifdef USE_GROVE
-    printColorText("\x1b[31mGROVE\x1b[39m Mode\n");
-#else
-    printColorText("\x1b[31mNOT GROVE\x1b[39m Mode\n");
-#endif
-    char log_msg[50];
-    sprintf(log_msg, "I2C address \x1b[33m0x%02x\x1b[39m", i2cAddress);
-    printColorText(log_msg);
+  : qrCodeData(""), PrimitiveLCD() {
+  setRotation(lcd_rotation);
+  clear();
+  setTextSize(1.5);
 }
 
 // e.g. atoms3lcd.drawImage(atoms3lcd.jpegBuf, atoms3lcd.jpegLength);
 void AtomS3LCD::drawImage(uint8_t* jpegBuf, uint32_t jpegLength) {
-    lcd.drawJpg(jpegBuf, jpegLength, 0, 0, 128, 128, 0, 0, ::JPEG_DIV_NONE);
+  drawJpg(jpegBuf, jpegLength, 0, 0, 128, 128, 0, 0, ::JPEG_DIV_NONE);
 }
 
 void AtomS3LCD::drawQRcode(const String& qrCodeData) {
-    if (qrCodeData.length() > 0) {
-      // Draw QR code if qrCodeData is received
-      lcd.fillScreen(lcd.color565(255, 255, 255));
-      lcd.qrcode(qrCodeData.c_str(), SPACING, SPACING / 2, lcd.width() - SPACING * 2, QR_VERSION);
-    }
-    else {
-      lcd.fillScreen(lcd.color565(255, 0, 0));  // Fill the screen with red
-      lcd.setCursor(0, 0);
-      lcd.println("No QR code data received.");
-    }
+  if (qrCodeData.length() > 0) {
+    // Draw QR code if qrCodeData is received
+    fillScreen(color565(255, 255, 255));
+    qrcode(qrCodeData.c_str(), SPACING, SPACING / 2, width() - SPACING * 2, QR_VERSION);
+  }
+  else {
+    fillScreen(color565(255, 0, 0));  // Fill the screen with red
+    setCursor(0, 0);
+    println("No QR code data received.");
+  }
+}
+
+void AtomS3LCD::printWaitMessage(int i2cAddress) {
+  printColorText("Wait for I2C input.\n");
+#ifdef USE_GROVE
+  printColorText("\x1b[31mGROVE\x1b[39m Mode\n");
+#else
+  printColorText("\x1b[31mNOT GROVE\x1b[39m Mode\n");
+#endif
+  char log_msg[50];
+  sprintf(log_msg, "I2C address \x1b[33m0x%02x\x1b[39m", i2cAddress);
+  printColorText(log_msg);
 }
 
 void AtomS3LCD::drawNoDataReceived() {
-  lcd.fillScreen(lcd.color565(255, 0, 0));  // Fill the screen with red
-  lcd.setCursor(0, 0);
-  lcd.println("No data received.");
+  fillScreen(color565(255, 0, 0));  // Fill the screen with red
+  setCursor(0, 0);
+  printColorText("No data received.\n");
 }
 
 void AtomS3LCD::drawBlack() {
-  lcd.fillScreen(lcd.color565(0, 0, 0));  // Fill the screen with black
-  lcd.setCursor(0, 0);
+  fillScreen(color565(0, 0, 0));  // Fill the screen with black
+  setCursor(0, 0);
 }
 
 void AtomS3LCD::resetColorStr() {
@@ -133,36 +67,8 @@ void AtomS3LCD::resetLcdData() {
   mode_changed = true;
 }
 
-void AtomS3LCD::setTextSize(float x) {
-  lcd.setTextSize(x);
-}
-
-void AtomS3LCD::fillRect(int x1, int y1, int w, int h, uint16_t color) {
-  lcd.fillRect(x1, y1, w, h, color);
-}
-
-void AtomS3LCD::drawRect(int x1, int y1, int w, int h, uint16_t color) {
-  lcd.drawRect(x1, y1, w, h, color);
-}
-
-void AtomS3LCD::drawLine(int x1, int y1, int x2, int y2, uint16_t color){
-  lcd.drawLine(x1, y1, x2, y2, color);
-};
-
-void AtomS3LCD::drawPixel(int x, int y, uint16_t color){
-  lcd.drawPixel(x, y, color);
-};
-
-void AtomS3LCD::setCursor(int x, int y){
-  lcd.setCursor(x,y);
-};
-
-uint16_t AtomS3LCD::color565(uint8_t red, uint8_t green, uint8_t blue){
-  return lcd.color565(red,green,blue);
-};
-
 unsigned long AtomS3LCD::getLastDrawTime() {
-    return lastDrawTime;
+  return lastDrawTime;
 }
 
 void AtomS3LCD::setLastDrawTime(unsigned long time) {

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -38,13 +38,6 @@ public:
   void printWaitMessage(int i2cAddress);
 
   /**
-   * @brief Print a message to the LCD screen.
-   *
-   * @param message The message to be printed.
-   */
-  void printMessage(const String& message);
-
-  /**
    * @brief Print colored text using ANSI-style escape sequences.
    *
    * @param input The input string containing ANSI escape codes.

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/atom_s3_lcd.h
@@ -1,9 +1,7 @@
 #ifndef ATOM_S3_LCD_H
 #define ATOM_S3_LCD_H
 
-#define LGFX_M5ATOMS3
-#include <LovyanGFX.hpp>
-#include <LGFX_AUTODETECT.hpp>
+#include <primitive_lcd.h>
 
 #define LCD_W 128
 #define LCD_H 128
@@ -11,7 +9,7 @@
 /**
  * @brief Class to handle the LCD on the AtomS3 using the LovyanGFX library.
  */
-class AtomS3LCD {
+class AtomS3LCD : public PrimitiveLCD {
 public:
   /**
    * @brief Constructor to initialize the LCD with a specific rotation.
@@ -19,30 +17,6 @@ public:
    * @param rotation The screen rotation (e.g., landscape, portrait).
    */
   AtomS3LCD();
-
-  /**
-   * @brief Initialize the LCD screen and set default properties.
-   */
-  void init();
-
-  /**
-   * @brief Clear the LCD screen.
-   */
-  void clear();
-
-  /**
-   * @brief Display a wait message and show whether GROVE mode is active.
-   *
-   * @param i2cAddress The I2C address to display on the screen.
-   */
-  void printWaitMessage(int i2cAddress);
-
-  /**
-   * @brief Print colored text using ANSI-style escape sequences.
-   *
-   * @param input The input string containing ANSI escape codes.
-   */
-  void printColorText(const String& input);
 
   /**
    * @brief Draw a JPEG image on the LCD screen.
@@ -60,6 +34,13 @@ public:
   void drawQRcode(const String& qrCodeData);
 
   /**
+   * @brief Display a wait message and show whether GROVE mode is active.
+   *
+   * @param i2cAddress The I2C address to display on the screen.
+   */
+  void printWaitMessage(int i2cAddress);
+
+  /**
    * @brief Display a "No data received" error message on the screen.
    */
   void drawNoDataReceived();
@@ -73,13 +54,6 @@ public:
   void resetJpegBuf();
   void resetQRcodeData();
   void resetLcdData();
-  void setTextSize(float x);
-  void fillRect(int x1, int y1, int x2, int y2, uint16_t color);
-  void drawRect(int x1, int y1, int x2, int y2, uint16_t color);
-  void drawLine(int x1, int y1, int x2, int y2, uint16_t color);
-  void drawPixel(int x, int y, uint16_t color);
-  void setCursor(int x, int y);
-  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue);
   unsigned long getLastDrawTime();
   void setLastDrawTime(unsigned long time);
 
@@ -104,21 +78,12 @@ public:
   String qrCodeData; /**< Stores the data to be encoded in the QR code. */
 
 private:
-  LGFX lcd;  /**< Instance of LovyanGFX for controlling the LCD. */
 #ifdef LCD_ROTATION
   static constexpr int lcd_rotation = LCD_ROTATION; /**< Current rotation of the LCD. */
 #else
   static constexpr int lcd_rotation = 1; /**< Current rotation of the LCD. */
 #endif
   unsigned long lastDrawTime = 0;
-  /**
-   * @brief Convert ANSI color codes to RGB565 values for foreground or background.
-   *
-   * @param code The ANSI color code.
-   * @param isBackground Whether the color is for the background (true) or foreground (false).
-   * @return The RGB565 color value.
-   */
-  uint16_t colorMap(int code, bool isBackground = false);
 };
 
 #endif // ATOM_S3_LCD_H

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/primitive_lcd.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/primitive_lcd.cpp
@@ -1,0 +1,152 @@
+#include <primitive_lcd.h>
+
+PrimitiveLCD::PrimitiveLCD() : LGFX() {
+  init();
+  lcdMutex = xSemaphoreCreateMutex();
+}
+
+void PrimitiveLCD::drawJpg(const uint8_t *jpg_data, size_t jpg_len, uint16_t x, uint16_t y, uint16_t maxWidth, uint16_t maxHeight, uint16_t offX, uint16_t offY, jpeg_div_t scale) {
+  if (lockLcd()) {
+    LGFX::drawJpg(jpg_data, jpg_len, x, y, maxWidth, maxHeight, offX, offY, scale);
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::qrcode(const char *string, uint16_t x, uint16_t y, uint8_t width, uint8_t version) {
+  if (lockLcd()) {
+    LGFX::qrcode(string, x, y, width, version);
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::printColorText(const String& input) {
+  String text = input;
+  uint16_t textColor = LGFX::color565(255, 255, 255); // Default text color: white
+  uint16_t bgColor = LGFX::color565(0, 0, 0);         // Default background color: black
+  int index = 0;
+  if (lockLcd()) {
+    while (index < text.length()) {
+      if (text.charAt(index) == '\x1b' && text.charAt(index + 1) == '[') {
+        int mIndex = text.indexOf('m', index);
+        if (mIndex != -1) {
+          String seq = text.substring(index + 2, mIndex);
+          int code = seq.toInt();
+          if (seq.startsWith("4")) {
+            bgColor = colorMap(code, true);
+          } else if (seq.startsWith("3")) {
+            textColor = colorMap(code, false);
+          }
+          text.remove(index, mIndex - index + 1);
+          continue;
+        }
+      }
+      LGFX::setTextColor(textColor, bgColor);
+      LGFX::print(text.charAt(index));
+      index++;
+    }
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::fillScreen(uint16_t color) {
+  if (lockLcd()) {
+    LGFX::fillScreen(color);
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::fillRect(int x1, int y1, int w, int h, uint16_t color) {
+  if (lockLcd()) {
+    LGFX::fillRect(x1, y1, w, h, color);
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::drawRect(int x1, int y1, int w, int h, uint16_t color) {
+  if (lockLcd()) {
+    LGFX::drawRect(x1, y1, w, h, color);
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::drawLine(int x1, int y1, int x2, int y2, uint16_t color){
+  if (lockLcd()) {
+    LGFX::drawLine(x1, y1, x2, y2, color);
+    unlockLcd();
+  }
+};
+
+void PrimitiveLCD::drawPixel(int x, int y, uint16_t color){
+  if (lockLcd()) {
+    LGFX::drawPixel(x, y, color);
+    unlockLcd();
+  }
+};
+
+void PrimitiveLCD::setCursor(int x, int y){
+  if (lockLcd()) {
+    LGFX::setCursor(x,y);
+    unlockLcd();
+  }
+};
+
+void PrimitiveLCD::setRotation(int lcd_rotation){
+  if (lockLcd()) {
+    LGFX::setRotation(lcd_rotation);
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::clear(){
+  if (lockLcd()) {
+    LGFX::clear();
+    unlockLcd();
+  }
+}
+
+void PrimitiveLCD::setTextSize(float text_size){
+  if (lockLcd()) {
+    LGFX::setTextSize(text_size);
+    unlockLcd();
+  }
+}
+
+uint16_t PrimitiveLCD::colorMap(int code, bool isBackground) {
+  if (isBackground) {
+    switch (code) {
+    case 40: return LGFX::color565(0, 0, 0);     // Black
+    case 41: return LGFX::color565(255, 0, 0);   // Red
+    case 42: return LGFX::color565(0, 255, 0);   // Green
+    case 43: return LGFX::color565(255, 255, 0); // Yellow
+    case 44: return LGFX::color565(0, 0, 255);   // Blue
+    case 45: return LGFX::color565(255, 0, 255); // Magenta
+    case 46: return LGFX::color565(0, 255, 255); // Cyan
+    case 47: return LGFX::color565(255, 255, 255); // White
+    case 49: return LGFX::color565(0, 0, 0);     // Default (Black)
+    default: return LGFX::color565(0, 0, 0);
+    }
+  } else {
+    switch (code) {
+    case 30: return LGFX::color565(0, 0, 0);     // Black
+    case 31: return LGFX::color565(255, 0, 0);   // Red
+    case 32: return LGFX::color565(0, 255, 0);   // Green
+    case 33: return LGFX::color565(255, 255, 0); // Yellow
+    case 34: return LGFX::color565(0, 0, 255);   // Blue
+    case 35: return LGFX::color565(255, 0, 255); // Magenta
+    case 36: return LGFX::color565(0, 255, 255); // Cyan
+    case 37: return LGFX::color565(255, 255, 255); // White
+    case 39: return LGFX::color565(255, 255, 255); // Default (White)
+    default: return LGFX::color565(255, 255, 255);
+    }
+  }
+}
+  
+bool PrimitiveLCD::lockLcd() {
+  // ミューテックスのロックを試みる（最大100ms待機）
+  return xSemaphoreTake(lcdMutex, pdMS_TO_TICKS(100)) == pdTRUE;
+}
+
+void PrimitiveLCD::unlockLcd() {
+  // ミューテックスを解放
+  xSemaphoreGive(lcdMutex);
+}

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/primitive_lcd.h
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_lcd/primitive_lcd.h
@@ -1,0 +1,38 @@
+#ifndef PRIMITIVE_LCD_H
+#define PRIMITIVE_LCD_H
+
+#define LGFX_M5ATOMS3
+#include <LovyanGFX.hpp>
+#include <LGFX_AUTODETECT.hpp>
+
+class PrimitiveLCD : public LGFX {
+public:
+  PrimitiveLCD();
+  void drawJpg(const uint8_t *jpg_data, size_t jpg_len, uint16_t x = 0, uint16_t y = 0, uint16_t maxWidth = 0, uint16_t maxHeight = 0, uint16_t offX = 0, uint16_t offY = 0, jpeg_div_t scale = JPEG_DIV_NONE);
+  void qrcode(const char *string, uint16_t x, uint16_t y, uint8_t width, uint8_t version);
+  void printColorText(const String& input);
+  void fillScreen(uint16_t color);
+  void fillRect(int x1, int y1, int w, int h, uint16_t color);
+  void drawRect(int x1, int y1, int w, int h, uint16_t color);
+  void drawLine(int x1, int y1, int x2, int y2, uint16_t color);
+  void drawPixel(int x, int y, uint16_t color);
+  void setCursor(int x, int y);
+  void setRotation(int lcd_rotation);
+  void clear();
+  void setTextSize(float text_size);
+  /**
+   * @brief Convert ANSI color codes to RGB565 values for foreground or background.
+   *
+   * @param code The ANSI color code.
+   * @param isBackground Whether the color is for the background (true) or foreground (false).
+   * @return The RGB565 color value.
+   */
+  uint16_t colorMap(int code, bool isBackground);
+
+private:
+  SemaphoreHandle_t lcdMutex;
+  bool lockLcd();
+  void unlockLcd();
+};
+
+#endif // PRIMITIVE_LCD_H

--- a/firmware/atom_s3_i2c_display/lib/atom_s3_mode_manager/atom_s3_mode_manager.cpp
+++ b/firmware/atom_s3_i2c_display/lib/atom_s3_mode_manager/atom_s3_mode_manager.cpp
@@ -49,7 +49,7 @@ void AtomS3ModeManager::task(void *parameter) {
     // If no mode is added, do nothing
     if (selectedModes.size() == 0) {
       instance->atoms3lcd.drawBlack();
-      instance->atoms3lcd.printMessage("Waiting for modes to be added...");
+      instance->atoms3lcd.printColorText("Waiting for modes to be added...\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }
@@ -120,7 +120,7 @@ void AtomS3ModeManager::changeMode(int suspend_mode_index, int resume_mode_index
   selectedModes[suspend_mode_index]->waitForTaskSuspended();
   instance->atoms3i2c.stopReceiveEvent();
   instance->atoms3lcd.drawBlack();
-  instance->atoms3lcd.printMessage("Wait for mode switch ...");
+  instance->atoms3lcd.printColorText("Wait for mode switch ...\n");
   vTaskDelay(pdMS_TO_TICKS(1000));
   instance->atoms3lcd.resetLcdData();
   // Resume

--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
@@ -13,7 +13,7 @@ void DisplayBatteryGraphMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
@@ -13,7 +13,7 @@ void DisplayImageMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
@@ -13,7 +13,7 @@ void DisplayInformationMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/display_odom_mode/display_odom_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_odom_mode/display_odom_mode.cpp
@@ -13,7 +13,7 @@ void DisplayOdomMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/display_qrcode_mode/display_qrcode_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_qrcode_mode/display_qrcode_mode.cpp
@@ -13,7 +13,7 @@ void DisplayQRcodeMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/pressure_control_mode/pressure_control_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pressure_control_mode/pressure_control_mode.cpp
@@ -13,7 +13,7 @@ void PressureControlMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/servo_control_mode/servo_control_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/servo_control_mode/servo_control_mode.cpp
@@ -13,7 +13,7 @@ void ServoControlMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }

--- a/firmware/atom_s3_i2c_display/lib/teaching_mode/teaching_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/teaching_mode/teaching_mode.cpp
@@ -13,7 +13,7 @@ void TeachingMode::task(void *parameter) {
     // Check for I2C timeout
     if (instance->atoms3i2c.checkTimeout()) {
       instance->atoms3lcd.drawNoDataReceived();
-      instance->atoms3lcd.printMessage(instance->getModeName());
+      instance->atoms3lcd.printColorText(instance->getModeName() + "\n");
       vTaskDelay(pdMS_TO_TICKS(500));
       continue;
     }


### PR DESCRIPTION
### Issue
When multiple tasks attempt to draw on the AtomS3 LCD simultaneously, it occasionally causes the screen to turn completely white or the program to freeze.

### Solution:
mutex has been introduced to ensure exclusive access to the LCD during drawing operations.

### Changes
Seperate AtomS3LCD class into PrimitiveLCD class and AtomS3LCD class.

- `PrimitiveLCD` class includes drawing functions that internally use a MUTEX to prevent simultaneous access. Note that use `LGFX::` in the PrimitiveLCD methods. This operator is needed to use original LGFX function.

- `AtomS3LCD` class uses the drawing functions from the PrimitiveLCD class for screen rendering. It does not directly access the mutex.