### PR TITLE
[TeachingMode] When mode is changed, state automatically returns to WAIT

### DIFF
--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -98,6 +98,9 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
 
     def timer_callback(self, event):
         if self.mode != "TeachingMode":
+            # When mode is changed,
+            # state automatically returns to WAIT
+            self.state = State.WAIT
             return
         sent_str = chr(PacketType.TEACHING_MODE)
         if self.state == State.WAIT:


### PR DESCRIPTION
Currently, once in the PLAY state, it will not return to the WAIT state unless the following operations are performed. (inconvenient)
- All recorded actions are erased.
- Playback any action.

With this pull request, it will automatically return to WAIT state when AtomS3 enters another mode by pressing and holding the button.