### PR TITLE
Record/Play special actions in teaching_mode.py

### DIFF
--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -100,14 +100,13 @@ class MotionManager:
     def get_actions(self):
         return self.special_actions
 
-    def add_action(self, start_time, name, start_command, stop_command):
+    def add_action(self, start_time, name, command):
         """Record special command
 
         Args:
         start_time[rospy.rostime.Time]: Start time of record
-        name[str]: e.g. 'grasp'
-        start_command[str]: e.g. 'ri.start_grasp()'
-        stop_command[str]: e.g. 'ri.stop_grasp()'
+        name[str]: Command name. e.g. 'grasp'
+        command[str]: Command to be recorded. e.g. 'ri.start_grasp()'
 """
         now = rospy.Time.now()
         elapsed_time = (now - start_time).to_sec()
@@ -116,14 +115,12 @@ class MotionManager:
             'special_action':
             {
                 'name': name,
-                'start_command': start_command,
-                'stop_command': stop_command,
+                'command': command,
             }
         })
         rospy.loginfo('Add special action')
         rospy.loginfo(
-            f'Time: {elapsed_time}, name: {name}, ' +\
-            f'start_command: {start_command}, stop_command: {stop_command}')
+            f'Time: {elapsed_time}, name: {name}, command: {command}')
 
     def play_motion(self, motion):
         """Executes a sequence of motions with safety checks and interruption handling.

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -47,6 +47,15 @@ class MotionManager:
         self.special_actions = []
         self.start()
 
+    def exec_with_error_handling(self, command):
+        """Execute command from string
+
+"""
+        try:
+            exec(command)
+        except Exception as e:
+            rospy.logerr(f"[Special action] {e}")
+
     def stop(self):
         """Stops the motion execution.
 
@@ -122,7 +131,59 @@ class MotionManager:
         rospy.loginfo(
             f'Time: {elapsed_time}, name: {name}, command: {command}')
 
-    def play_motion(self, motion):
+    def parse_motion(self, motion, actions):
+        """
+        ロボットの動作データを処理し、joint_statesとspecial_actionで分類する関数
+
+        Args:
+            data: JSON形式のロボット動作データ
+
+        Returns:
+            処理済みのデータを含む辞書
+        """
+        sorted_motion = sorted(motion, key=lambda x: x['time'])
+        sorted_actions = sorted(actions, key=lambda x: x['time'])
+        special_actions = []
+        joint_states = []
+        for item in sorted_motion:
+            if 'joint_states' not in item:
+                rospy.logerr("Cannot parse data. Invalid motion is given.")
+                return
+            joint_states.append(item)
+        for item in sorted_actions:
+            if 'special_action' not in item:
+                rospy.logerr("Cannot parse data. Invalid actions are given.")
+                return
+            special_actions.append(item)
+        # special_actionの時間でjoint_statesを分割
+        motion_segments = []
+        current_segment = []
+        special_action_times = [action['time'] for action in special_actions]
+        for state in joint_states:
+            time = state['time']
+            # 現在のsegmentを決定
+            should_start_new_segment = False
+            if current_segment:
+                for special_time in special_action_times:
+                    if time > special_time and current_segment[-1]['time'] < special_time:
+                        should_start_new_segment = True
+                        break
+            if should_start_new_segment:
+                motion_segments.append(current_segment)
+                current_segment = []
+            current_segment.append(state)
+        # 最後のセグメントを追加
+        if current_segment:
+            motion_segments.append(current_segment)
+        if len(motion_segments) != len(special_actions) + 1:
+            rospy.logerr("Parse failed.")
+            return
+        return {
+            "motion_segments": motion_segments,
+            "special_actions": special_actions
+        }
+
+    def play_motion(self, motion, actions):
         """Executes a sequence of motions with safety checks and interruption handling.
 
 Returns message[str] to show on AtomS3 LCD
@@ -137,28 +198,48 @@ Returns message[str] to show on AtomS3 LCD
         self.ri.wait_interpolation()
         # Play the actions from the second one onward
         prev_time = motion[0]['time']
-        avs = []
-        tms = []
-        for m in motion[1:]:
-            current_time = m['time']
-            # Send angle vector
-            if 'joint_states' in m:
-                av = np.array(list(m['joint_states'].values()))
-                avs.append(av)
-                tms.append(current_time - prev_time)
-            prev_time = current_time
-        rospy.loginfo('angle vectors')
-        rospy.loginfo(f'{avs}')
-        rospy.loginfo('times')
-        rospy.loginfo(f'{tms}')
-        self.ri.angle_vector_sequence(avs, tms)
-        # Check interruption by button
-        while not rospy.is_shutdown() and self.ri.is_interpolating():
-            if self.is_stopped():
-                self.ri.cancel_angle_vector()
-                rospy.loginfo('Play interrupted')
-                break
-            rospy.sleep(0.5)  # Save motion every 0.5s to smooth motion play
+        _ = self.parse_motion(motion[1:], actions)
+        motion_segments = _["motion_segments"]
+        special_actions = _["special_actions"]
+        # Separate motions by special action and play them in turns
+        for i, motion_segment in enumerate(motion_segments):
+            avs = []
+            tms = []
+            filtered_motion_segment = [m for m in motion_segment
+                                       if m['time'] >= prev_time]
+            # Play motion segment
+            for m in filtered_motion_segment:
+                current_time = m['time']
+                # Send angle vector
+                if 'joint_states' in m:
+                    av = np.array(list(m['joint_states'].values()))
+                    avs.append(av)
+                    tms.append(current_time - prev_time)
+                prev_time = current_time
+            rospy.loginfo('angle vectors')
+            rospy.loginfo(f'{avs}')
+            rospy.loginfo('times')
+            rospy.loginfo(f'{tms}')
+            self.ri.angle_vector_sequence(avs, tms)
+            # Check interruption by button
+            while not rospy.is_shutdown() and self.ri.is_interpolating():
+                if self.is_stopped():
+                    self.ri.cancel_angle_vector()
+                    rospy.loginfo('Play interrupted')
+                    break
+                rospy.sleep(0.5)  # Save motion every 0.5s to smooth motion play
+            # Play special action
+            start_time = rospy.Time.now()
+            if i < len(special_actions):
+                action = special_actions[i]["special_action"]
+                rospy.loginfo('Run special action')
+                rospy.loginfo(
+                    f'name: {action["name"]}, command: {action["command"]}')
+                self.exec_with_error_handling(
+                    action["command"])
+            elapsed_time = (rospy.Time.now() - start_time).to_sec()
+            # Skip motions recorded during special action
+            prev_time += elapsed_time
         message = 'Play finished'
         rospy.loginfo(message)
         return message

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -15,9 +15,17 @@ class MotionManager:
     playing motions, and adjusting motions using inverse kinematics (IK).
 
     Attributes:
-        tfl (TransformListener): An instance of ROS TransformListener used for retrieving TF transformations.
-        markers (list): A list of previously recorded marker information.
-        marker_msg (AprilTagDetectionArray): The latest marker detection data.
+        ri (KXRROSRobotInterface): Interface for controlling the robot.
+        joint_names (list): List of joint names for the robot.
+        end_coords_name (str): Name of the end-effector coordinates link.
+        motion (list): Recorded motion sequences. Each entry is a dictionary with:
+            - 'time' (float): Time in seconds.
+            - 'joint_states' (dict): Joint states mapping joint names to their angles (float).
+        special_actions (list): Special commands and actions linked to the motion. Each entry is a dictionary with:
+            - 'time' (float): Time in seconds.
+            - 'special_action' (dict): Action details containing:
+                - 'name' (str): Action name.
+                - 'command' (str): Command string to execute.
     """
 
     def __init__(self):
@@ -48,42 +56,54 @@ class MotionManager:
         self.start()
 
     def exec_with_error_handling(self, command):
-        """Execute command from string
+        """Executes a command string with error handling.
 
-"""
+        Args:
+            command (str): Python command to execute.
+        """
         try:
             exec(command)
         except Exception as e:
             rospy.logerr(f"[Special action] {e}")
 
     def stop(self):
-        """Stops the motion execution.
-
-"""
+        """Stops the motion execution."""
         self._stop = True
 
     def start(self):
-        """Resumes the motion execution.
-
-"""
+        """Resumes the motion execution."""
         self._stop = False
 
     def is_stopped(self):
         """Checks if the motion execution is stopped.
 
-"""
+        Returns:
+            bool: True if motion execution is stopped, False otherwise.
+        """
         return self._stop is True
 
     def set_motion(self, motion):
+        """Sets the motion sequence.
+
+        Args:
+            motion (list): List of motion states.
+        """
         self.motion = motion
 
     def get_motion(self):
+        """Gets the current motion sequence.
+
+        Returns:
+            list: The current motion sequence.
+        """
         return self.motion
 
     def add_motion(self, start_time):
         """Records the robot's current pose and adds it to the motion sequence.
 
-"""
+        Args:
+            start_time (rospy.Time): The starting time of the motion recording.
+        """
         joint_states = {}
         # Average multiple angle vectors to reduce the noise
         # of the servo motor's potentiometer
@@ -104,19 +124,29 @@ class MotionManager:
         rospy.loginfo(f'Time: {elapsed_time}, joint_states: {joint_states}')
 
     def set_actions(self, actions):
+        """Sets the list of special actions.
+
+        Args:
+            actions (list): List of special actions.
+        """
         self.special_actions = actions
 
     def get_actions(self):
+        """Gets the current list of special actions.
+
+        Returns:
+            list: The current special actions.
+        """
         return self.special_actions
 
     def add_action(self, start_time, name, command):
-        """Record special command
+        """Records a special action with its execution command.
 
         Args:
-        start_time[rospy.rostime.Time]: Start time of record
-        name[str]: Command name. e.g. 'grasp'
-        command[str]: Command to be recorded. e.g. 'ri.start_grasp()'
-"""
+            start_time (rospy.Time): The starting time of the action recording.
+            name (str): Name of the action (e.g., 'grasp').
+            command (str): Python command to execute the action.
+        """
         now = rospy.Time.now()
         elapsed_time = (now - start_time).to_sec()
         self.special_actions.append({
@@ -186,8 +216,9 @@ class MotionManager:
     def play_motion(self, motion, actions):
         """Executes a sequence of motions with safety checks and interruption handling.
 
-Returns message[str] to show on AtomS3 LCD
-"""
+        Returns:
+            message (str): Message shown on AtomS3 LCD
+        """
         # To prevent sudden movement, take time to reach the initial motion
         if 'joint_states' not in motion[0]:
             print("First element must have 'joint_states' key.")
@@ -246,10 +277,21 @@ Returns message[str] to show on AtomS3 LCD
 
     def move_motion(self, motion, target_coords, local_coords):
         """Adjusts a motion sequence to align with a specified target pose using inverse kinematics (IK).
-Returns (moved_motion[json] or False, message[str])
-if IK succeed, moved_motion is [json].
-if IK fail, moved_motion is False.
-"""
+
+        This method modifies a given motion sequence by applying IK to align the end-effector
+        with a specified target position and orientation. If IK fails consecutively beyond
+        a certain limit, the process terminates and returns an error message.
+
+        Args:
+            motion (list): A list of motion states.
+            target_coords (Coords): Target coordinates for the end-effector in the global frame.
+            local_coords (Coords): Local offset coordinates relative to the target position.
+
+        Returns:
+            tuple: A tuple containing:
+                - moved_motion (list or bool): Updated motion sequence if successful, or False if IK fails.
+                - message (str): Success or error message.
+        """
         if self.end_coords_name is None:
             error_message = "end_coords_name param is not set."
             rospy.logerr(error_message)

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -44,6 +44,7 @@ class MotionManager:
            and self.end_coords_name not in link_names:
             rospy.logerr('end_coords name does not match link name.')
         self.motion = []
+        self.special_actions = []
         self.start()
 
     def stop(self):
@@ -92,6 +93,37 @@ class MotionManager:
         })
         rospy.loginfo('Add new joint states')
         rospy.loginfo(f'Time: {elapsed_time}, joint_states: {joint_states}')
+
+    def set_actions(self, actions):
+        self.special_actions = actions
+
+    def get_actions(self):
+        return self.special_actions
+
+    def add_action(self, start_time, name, start_command, stop_command):
+        """Record special command
+
+        Args:
+        start_time[rospy.rostime.Time]: Start time of record
+        name[str]: e.g. 'grasp'
+        start_command[str]: e.g. 'ri.start_grasp()'
+        stop_command[str]: e.g. 'ri.stop_grasp()'
+"""
+        now = rospy.Time.now()
+        elapsed_time = (now - start_time).to_sec()
+        self.special_actions.append({
+            'time': elapsed_time,
+            'special_action':
+            {
+                'name': name,
+                'start_command': start_command,
+                'stop_command': stop_command,
+            }
+        })
+        rospy.loginfo('Add special action')
+        rospy.loginfo(
+            f'Time: {elapsed_time}, name: {name}, ' +\
+            f'start_command: {start_command}, stop_command: {stop_command}')
 
     def play_motion(self, motion):
         """Executes a sequence of motions with safety checks and interruption handling.

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -256,9 +256,11 @@ class MotionManager:
             while not rospy.is_shutdown() and self.ri.is_interpolating():
                 if self.is_stopped():
                     self.ri.cancel_angle_vector()
-                    rospy.loginfo('Play interrupted')
                     break
                 rospy.sleep(0.5)  # Save motion every 0.5s to smooth motion play
+            if self.is_stopped():
+                rospy.loginfo('Play interrupted')
+                break
             # Play special action
             start_time = rospy.Time.now()
             if i < len(special_actions):

--- a/riberry/select_list.py
+++ b/riberry/select_list.py
@@ -10,8 +10,11 @@ class SelectList:
         self.idx = 0
         self.pattern = None
 
-    def add_option(self, item):
-        self.options.insert(0, item)
+    def add_option(self, item, position="start"):
+        if position == "start":
+            self.options.insert(0, item)
+        elif position == "end":
+            self.options.append(item)
 
     def remove_option(self, item):
         self.options.remove(item)

--- a/riberry/teaching_manager.py
+++ b/riberry/teaching_manager.py
@@ -40,6 +40,7 @@ class TeachingManager:
             with open(play_filepath) as f:
                 json_data = json.load(f)
                 self.motion_manager.set_motion([j for j in json_data if 'joint_states' in j])
+                self.motion_manager.set_actions([j for j in json_data if 'special_action' in j])
                 self.marker_manager.set_markers([j for j in json_data if 'marker_id' in j])
             rospy.loginfo(f'Loaded motion data: {self.motion_manager.get_motion()}')
             rospy.loginfo(f'Loaded marker data {self.marker_manager.get_markers()}')
@@ -122,8 +123,10 @@ class TeachingManager:
         # Play motion
         rospy.loginfo('Play motion')
         recorded_motion = self.motion_manager.get_motion()
+        special_actions = self.motion_manager.get_actions()
         if len(self.marker_manager.get_markers()) == 0:
-            return self.motion_manager.play_motion(recorded_motion)
+            return self.motion_manager.play_motion(
+                recorded_motion, special_actions)
         else:
             # The entire movement is performed again after the initial posture
             # to compensate for deflection of the arm due to gravity
@@ -159,4 +162,5 @@ class TeachingManager:
             if moved_motion is False:
                 return message
             else:
-                return self.motion_manager.play_motion(moved_motion)
+                return self.motion_manager.play_motion(
+                    moved_motion, special_actions)

--- a/riberry/teaching_manager.py
+++ b/riberry/teaching_manager.py
@@ -73,6 +73,7 @@ class TeachingManager:
 
         self.motion_manager.start()
         self.motion_manager.set_motion([])
+        self.motion_manager.set_actions([])
         self.marker_manager.set_markers([])
         with open(record_filepath, mode='w') as f:
             rospy.loginfo(f'Start saving motion to {record_filepath}')
@@ -89,7 +90,9 @@ class TeachingManager:
                 rospy.sleep(0.1)
             f.write(
                 json.dumps(
-                    self.motion_manager.get_motion()+self.marker_manager.get_markers(),
+                    self.motion_manager.get_motion()+\
+                    self.motion_manager.get_actions()+\
+                    self.marker_manager.get_markers(),
                     indent=4, separators=(",", ": ")))
             rospy.loginfo(f'Finish saving motion to {record_filepath}')
         motion_duration = self.motion_manager.get_motion()[-1]["time"]

--- a/riberry/teaching_manager.py
+++ b/riberry/teaching_manager.py
@@ -17,7 +17,7 @@ class TeachingManager:
     Attributes:
         motion_manager (MotionManager): Instance managing motion trajectory recording and playback
         marker_manager (MarkerManager): Instance managing marker information processing
-        _stop (bool): Flag to control recording/playback termination
+        start_time (rospy.rostime.Time): Start time of motion
     """
 
     def __init__(self):
@@ -58,18 +58,18 @@ class TeachingManager:
         self.motion_manager.ri.servo_on()
 
     def record(self, record_filepath):
-        """Records motion and marker information and saves it to a JSON file
+        """Records motion and marker information and saves it to a JSON file.
 
         Args:
-            record_filepath (str): Path to the JSON file where data will be saved
+            record_filepath (str): Path to the JSON file where data will be saved.
 
         Returns:
             str: Message to display on AtomS3 LCD, including recorded motion duration,
-                number of motion points, and number of markers
+                number of motion points, and number of markers.
 
         Note:
-            Recording continues until self.motion_manager is stopped
-            Data is sampled at 0.1-second intervals
+            - Recording continues until `motion_manager` is stopped.
+            - Data is sampled at 0.1-second intervals.
         """
 
         self.motion_manager.start()
@@ -112,9 +112,9 @@ class TeachingManager:
             str: Message to display on AtomS3 LCD. Returns error message if an error occurs
 
         Note:
-            When markers are present in the recording, the playback motion is adjusted by
+            - If markers are present in the recording, the playback motion is adjusted by
             comparing current marker positions with recorded marker positions.
-            An error occurs if marker IDs don't match.
+            - An error occurs if marker IDs don't match.
         """
 
         self.motion_manager.start()

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from enum import Enum
 import os
+import threading
 
 import rospy
 from std_msgs.msg import Int32
@@ -104,10 +105,11 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
                     f'{action_state} {self.special_action_name}',
                     command)
                 # Execute
-                try:
-                    exec(command)
-                except Exception as e:
-                    rospy.logerr(f"[Special action {action_state.lower()} command]: {e}")
+                thread1 = threading.Thread(
+                    target=self.exec_with_error_handling,
+                    args=(command,),
+                    daemon=True)
+                thread1.start()
                 self.special_action_executed = not self.special_action_executed
             elif msg.data == 3:
                 self.teaching_manager.servo_off()
@@ -195,6 +197,15 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
             rospy.logerr(f"sent string: {sent_str}")
             rospy.logerr(f"The number of delimiter '{delimiter}' must be {delimiter_num}")
         self.send_string(sent_str)
+
+    def exec_with_error_handling(self, command):
+        """Execute command from string
+
+"""
+        try:
+            exec(command)
+        except Exception as e:
+            rospy.logerr(f"[Special action] {e}")
 
     def load_teaching_files(self):
         teaching_files = [

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -245,7 +245,7 @@ class TeachingMode(I2CBase):
                 if self.special_action_selected is None:
                     sent_str += 'None\n\n'
                 else:
-                    sent_str += 'Toggle\n'
+                    sent_str += 'Action\n'
                     if self.special_action_executed is True:
                         sent_str += '\x1b[32m ON   \x1b[39m'
                     else:

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -16,6 +16,14 @@ from riberry.teaching_manager import TeachingManager
 
 
 class State(Enum):
+    """
+    Enum representing the states of the TeachingMode.
+
+    Attributes:
+        WAIT (int): Idle state where no action is being performed.
+        RECORD (int): State for recording robot motions.
+        PLAY (int): State for playing back recorded motions.
+    """
     WAIT = 0
     RECORD = 1
     PLAY = 2
@@ -26,11 +34,23 @@ class TeachingMode(I2CBase):
     TeachingMode is a class that manages robot motion teaching and playback through AtomS3 communication.
 
     This class provides functionality to:
-    1. Record robot motions and save them as JSON files via TeachingManager class
-    2. Play back recorded motions via TeachingManager class
-    3. Control these operations via AtomS3 button inputs
+    - Record robot motion and special actions. Then save them as JSON files via TeachingManager class
+    - Play back recorded motions via TeachingManager class
+    - Control these operations via AtomS3 button inputs
 
-    Actual motion control and marker recognition are performed by a subordinate class, TeachingManager.
+    Attributes:
+        teaching_manager (TeachingManager): Handles motion and marker recording/playback. Actual motion control and marker recognition are performed by this instance.
+        json_dir (str): Directory to save and load JSON files for recorded motions.
+        play_list (SelectList): List of available motion files for playback.
+        recording (bool): Indicates whether the system is currently recording motions.
+        playing (bool): Indicates whether the system is currently playing motions.
+        mode (str): Current operational mode, as set by the `/atom_s3_mode` topic.
+        special_actions (list): Configurable list of special actions for recording.
+        special_action_selected (dict): The currently selected special action during recording.
+        special_action_executed (bool): Indicates if the selected special action is currently active.
+        prev_state (State): The previous state of the system.
+        state (State): The current state of the system.
+        additional_str (str): Additional message string for display during operations.
     """
 
     def __init__(self, i2c_addr):
@@ -67,18 +87,32 @@ class TeachingMode(I2CBase):
         self.special_action_executed = False
         self.prev_state = None
         self.state = State.WAIT
-        rospy.Timer(rospy.Duration(0.1), self.timer_callback)
+        rospy.Timer(rospy.Duration(0.1), self.update_atoms3)
         self.additional_str = ""
 
     def mode_cb(self, msg):
+        """Callback to update the current operational mode.
+
+        Args:
+            msg (std_msgs.msg.String): Message containing the mode string.
+        """
         self.mode = msg.data
 
     def button_cb(self, msg):
+        """Handles button state transitions for recording and playback.
+
+        Args:
+            msg (std_msgs.msg.Int32): Message containing the button state.
+
+        Note:
+            This class manages the internal state of its operations (e.g., self.state, self.playing, etc.).
+            It does not directly manage or influence the UI updates or external displays, such as those handled by
+            the self.update_atoms3 function.
+
+            Basic state transitions:
+            - WAIT -> RECORD -> WAIT (via single-click).
+            - WAIT -> PLAY -> WAIT (via double-click).
         """
-        Manage state by click
-Wait -> (Single-click) -> Record  -> (Single-click) -> Finish recording -> Wait
-Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) -> Abort -> Wait
-"""
         if self.mode != "TeachingMode":
             return
         if self.prev_state != self.state:
@@ -156,7 +190,17 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
                     self.teaching_manager.stop()
                     self.state = State.WAIT
 
-    def timer_callback(self, event):
+    def update_atoms3(self, event):
+        """Timer callback to update AtomS3 LCD with the current state and marker information.
+
+        Args:
+            event (rospy.TimerEvent): Timer event information.
+
+        Note:
+            This method is responsible for updating the UI and display information on the AtomS3 device.
+            It does not modify the internal state of this class (e.g., self.state, self.playing, etc.).
+            Instead, it reads these states and reflects them on the AtomS3 LCD.
+        """
         if self.mode != "TeachingMode":
             # When mode is changed,
             # state automatically returns to WAIT
@@ -222,6 +266,7 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
         self.send_string(sent_str)
 
     def load_teaching_files(self):
+        """Loads all teaching JSON files from the configured directory."""
         teaching_files = [
             os.path.join(self.json_dir, file)
             for file in os.listdir(self.json_dir)
@@ -235,6 +280,14 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
             self.play_list.add_option(file)
 
     def get_json_path(self, filename=None):
+        """Generates a path for a new or existing teaching JSON file.
+
+        Args:
+            filename (str, optional): Filename for the JSON file. Defaults to None.
+
+        Returns:
+            str: Full path to the teaching JSON file.
+        """
         if filename is None:
             current_time = datetime.now().strftime("%m%d_%H%M%S")
             json_path = os.path.join(
@@ -245,6 +298,7 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
         return json_path
 
     def main_loop(self):
+        """Main loop to manage the teaching mode operations."""
         rospy.loginfo('start teaching mode')
         try:
             while not rospy.is_shutdown():

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -48,6 +48,12 @@ class TeachingMode(I2CBase):
             Int32, callback=self.button_cb, queue_size=1)
         rospy.Subscriber(
             "/atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
+        self.special_action_name = rospy.get_param(
+            '~special_action_name', None)
+        self.special_action_start_command = rospy.get_param(
+            '~special_action_start_command', None)
+        self.special_action_stop_command = rospy.get_param(
+            '~special_action_stop_command', None)
         self.prev_state = None
         self.state = State.WAIT
         rospy.Timer(rospy.Duration(0.1), self.timer_callback)
@@ -81,6 +87,13 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
             if msg.data == 1:
                 self.teaching_manager.stop()
                 self.state = State.WAIT
+            # Record special action
+            elif msg.data == 2:
+                self.teaching_manager.motion_manager.add_action(
+                    self.teaching_manager.start_time,
+                    self.special_action_name,
+                    self.special_action_start_command,
+                    self.special_action_stop_command)
             elif msg.data == 3:
                 self.teaching_manager.servo_off()
         elif self.state == State.PLAY:
@@ -131,7 +144,15 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
         elif self.state == State.RECORD:
             self.additional_str = ""
             sent_str += 'Record mode\n\n'\
-                + '1tap: finish'
+                + '1tap: finish\n'
+            sent_str += '2tap: '
+            if self.special_action_name is None or\
+               self.special_action_start_command is None or\
+               self.special_action_stop_command is None:
+                sent_str += 'None\n'
+            else:
+                sent_str += f'{self.special_action_name}\n'
+            sent_str += '3tap: free'
         elif self.state == State.PLAY:
             self.additional_str = ""
             if self.playing is False:

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -148,11 +148,8 @@ class TeachingMode(I2CBase):
         # record until stopped
         if self.recording is False:
             self.start_recording()
-        # finish recording
-        if msg.data == 1:
-            self.stop_recording()
         # Record and execute special action
-        elif msg.data == 2:
+        if msg.data == 1:
             if self.special_action_executed is True:
                 action_state = 'Stop'
                 command = self.special_action_selected["stop_command"]
@@ -171,6 +168,9 @@ class TeachingMode(I2CBase):
                 daemon=True)
             thread1.start()
             self.special_action_executed = not self.special_action_executed
+        # finish recording
+        elif msg.data == 2:
+            self.stop_recording()
         elif msg.data == 3:
             self.teaching_manager.servo_off()
 
@@ -241,8 +241,7 @@ class TeachingMode(I2CBase):
                 sent_str += self.special_action_list.string_options(5)
             # Start recording
             else:
-                sent_str += '1tap: finish\n\n'
-                sent_str += '2tap: '
+                sent_str += '1tap: '
                 if self.special_action_selected is None:
                     sent_str += 'None\n\n'
                 else:
@@ -252,6 +251,7 @@ class TeachingMode(I2CBase):
                     else:
                         sent_str += '\x1b[31m OFF  \x1b[39m'
                     sent_str += f'{self.special_action_selected["name"]}\n\n'
+                sent_str += '2tap: finish\n\n'
                 sent_str += '3tap: free'
         elif self.state == State.PLAY:
             self.additional_str = ""

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -59,9 +59,9 @@ class TeachingMode(I2CBase):
                 rospy.logerr(f"special action must have key: {keys}.")
                 return
             action["start_command"] = action["start_command"].replace(
-                'ri.', 'self.teaching_manager.motion_manager.ri.')
+                'ri.', 'self.ri.')
             action["stop_command"] = action["stop_command"].replace(
-                'ri.', 'self.teaching_manager.motion_manager.ri.')
+                'ri.', 'self.ri.')
             self.special_action_list.add_option(action["name"], position="end")
         self.special_action_selected = None
         self.special_action_executed = False
@@ -124,7 +124,7 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
                     command)
                 # Execute
                 thread1 = threading.Thread(
-                    target=self.exec_with_error_handling,
+                    target=self.teaching_manager.motion_manager.exec_with_error_handling,
                     args=(command,),
                     daemon=True)
                 thread1.start()
@@ -189,7 +189,7 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
                 sent_str += '1tap: finish\n\n'
                 sent_str += '2tap: '
                 if self.special_action_selected is None:
-                    sent_str += 'None\n'
+                    sent_str += 'None\n\n'
                 else:
                     sent_str += 'Toggle\n'
                     if self.special_action_executed is True:
@@ -220,15 +220,6 @@ Wait -> (Double-click) -> Play -> (Double-click) -> Confirm -> (Double-click) ->
             rospy.logerr(f"sent string: {sent_str}")
             rospy.logerr(f"The number of delimiter '{delimiter}' must be {delimiter_num}")
         self.send_string(sent_str)
-
-    def exec_with_error_handling(self, command):
-        """Execute command from string
-
-"""
-        try:
-            exec(command)
-        except Exception as e:
-            rospy.logerr(f"[Special action] {e}")
 
     def load_teaching_files(self):
         teaching_files = [


### PR DESCRIPTION
## Overview

With this pull request,  `teaching_mode.py` record not only joint trajectory but also special actions.
Special actions are, for example, grasping, vacuuming, ... etc.

## Usage

1. Users set special actions by defining their names and commands in the `~special_actions` parameter. Multiple special actions can be defined. (See example code at the bottom of comments)

2. During record mode, special actions can be triggered by double-clicking the AtomS3. The timing of these special actions is recorded in the JSON output.

3. During play mode, teaching_mode.py executes both the recorded joint trajectories and the special actions at their recorded timestamps.

## Sample

```
<launch>
  <node name="teaching_mode"
        pkg="riberry_startup" type="teaching_mode.py"
        output="screen"
        respawn="true" clear_params="true">
    <rosparam>
      special_actions:
      - name: "test"
        start_command: "rospy.logwarn('start command test');"
        stop_command: "rospy.logwarn('stop command test');"
      - name: "grasp"
        start_command: "ri.servo_on(['gripper_dummy_joint']); ri.angle_vector(); ri.robot.gripper_dummy_joint.joint_angle(1.2); ri.angle_vector(ri.robot.angle_vector(), 2); rospy.sleep(2.5)"
        stop_command: "ri.servo_on(['gripper_dummy_joint']); ri.angle_vector(); ri.robot.gripper_dummy_joint.joint_angle(-1.2); ri.angle_vector(ri.robot.angle_vector(), 2); rospy.sleep(2.5)"
      - name: "vacuum"
        start_command: "ri.send_pressure_control(board_idx=39, trigger_pressure=-10, target_pressure=-30, release_duration=0)"
        stop_command: "ri.send_pressure_control(board_idx=39, trigger_pressure=-10, target_pressure=-30, release_duration=2)"
    </rosparam>
  </node>
</launch>
```

## Note

- The program described in each command can be written in the same way as when importing kxr_interface.py.