### PR TITLE
Add TeachingRobotInterface to use custom methods as special actions

### DIFF
--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -1,10 +1,11 @@
 import copy
 
-from kxr_controller.kxr_interface import KXRROSRobotInterface
 import numpy as np
 import rospy
 from skrobot.model import RobotModel
 from skrobot.utils.urdf import no_mesh_load_mode
+
+from riberry.teaching_interface import TeachingRobotInterface
 
 
 class MotionManager:
@@ -42,7 +43,7 @@ class MotionManager:
         with no_mesh_load_mode():
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
-        self.ri = KXRROSRobotInterface(
+        self.ri = TeachingRobotInterface(
             robot_model, namespace=namespace, controller_timeout=60.0
         )
         self.joint_names = self.ri.robot.joint_names

--- a/riberry/teaching_interface.py
+++ b/riberry/teaching_interface.py
@@ -1,0 +1,6 @@
+from kxr_controller.kxr_interface import KXRROSRobotInterface
+
+
+class TeachingRobotInterface(KXRROSRobotInterface):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
In special actions, instances and methods from `MotionManager` class can be used. 
To execute ROS functions, such as ActionClient and Publisher, the system now holds an instance of `TeachingRobotInterface`, which inherits from `KXRROSRobotInterface`. 
This change enables users to add methods to `TeachingRobotInterface`, making them callable as special actions.