### PR TITLE
Use compareIgnoringEscapeSequences instead of String::equals

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
@@ -1,4 +1,5 @@
 #include <display_information_mode.h>
+#include <string_utils.h>
 
 DisplayInformationMode* DisplayInformationMode::instance = nullptr;
 
@@ -26,7 +27,9 @@ void DisplayInformationMode::task(void *parameter) {
         instance->lcd.printColorText("Waiting for " + instance->getModeName());
         prevStr = "";
       } else {
-        if (prevStr.equals(instance->lcd.color_str)) {
+        // The reason for using this here is that the equals function relies on strcmp,
+        // which cannot properly handle escape sequences. As a result, it may fail to compare strings correctly.
+        if (compareIgnoringEscapeSequences(prevStr, instance->lcd.color_str)) {
           vTaskDelay(pdMS_TO_TICKS(10));
         } else {
           instance->lcd.drawBlack();

--- a/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_information_mode/display_information_mode.cpp
@@ -37,7 +37,7 @@ void DisplayInformationMode::task(void *parameter) {
           instance->lcd.printColorText(instance->lcd.color_str);
         }
       }
-      vTaskDelay(pdMS_TO_TICKS(1000));
+      vTaskDelay(pdMS_TO_TICKS(10));
     }
   }
 }

--- a/firmware/atom_s3_i2c_display/lib/utils/string_utils.h
+++ b/firmware/atom_s3_i2c_display/lib/utils/string_utils.h
@@ -1,0 +1,18 @@
+#ifndef STRING_UTILS_H
+#define STRING_UTILS_H
+
+
+bool compareIgnoringEscapeSequences(const String &str1, const String &str2) {
+  int i1 = 0, i2 = 0;
+  while (i1 < str1.length() && i2 < str2.length()) {
+    if (i1 >= str1.length() || i2 >= str2.length() || str1.charAt(i1) != str2.charAt(i2)) {
+      return false;
+    }
+    i1++;
+    i2++;
+  }
+  return i1 == str1.length() && i2 == str2.length();
+}
+
+
+#endif


### PR DESCRIPTION
The reason for using `compareIgnoringEscapeSequences` is that the equals function relies on strcmp,
which cannot properly handle escape sequences. As a result, it may fail to compare strings correctly.