### PR TITLE
Set ROS_MASTER_URI in get_roshost.py

### DIFF
--- a/ros/riberry_startup/scripts/get_roshost.py
+++ b/ros/riberry_startup/scripts/get_roshost.py
@@ -48,8 +48,8 @@ def get_roshost(retry=None, ros_master_ip=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='IP Address Parser')
     parser.add_argument(
-        '-r', '--rossetmaster', type=str, default=None,
-        help='ROS_MASTER_URI IP address')
+        '-', '--rossetmaster', type=str, nargs='?', const=None,
+        help='IP address to display (default: 8.8.8.8)')
     args = parser.parse_args()
 
     roshost = get_roshost(ros_master_ip=args.rossetmaster)

--- a/ros/riberry_startup/scripts/get_roshost.py
+++ b/ros/riberry_startup/scripts/get_roshost.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import socket
 import subprocess
 import time
@@ -32,14 +33,24 @@ def wait_and_get_ros_ip(retry=300):
     return None
 
 
-def get_roshost(retry=None):
+def get_roshost(retry=None, ros_master_ip=None):
     ros_ip = wait_and_get_ros_ip(retry or 300)
+    ros_script = ""
     if ros_ip:
-        return f"ROS_IP={ros_ip}"
+        ros_script += f"ROS_IP={ros_ip}"
     else:
-        return f"ROS_HOSTNAME={socket.gethostname()}.local"
+        ros_script += f"ROS_HOSTNAME={socket.gethostname()}.local"
+    if ros_master_ip is not None:
+        ros_script += f" ROS_MASTER_URI=http://{ros_master_ip}:11311"
+    return ros_script
 
 
 if __name__ == "__main__":
-    roshost = get_roshost()
+    parser = argparse.ArgumentParser(description='IP Address Parser')
+    parser.add_argument(
+        '-r', '--rossetmaster', type=str, default=None,
+        help='ROS_MASTER_URI IP address')
+    args = parser.parse_args()
+
+    roshost = get_roshost(ros_master_ip=args.rossetmaster)
     print(roshost)


### PR DESCRIPTION
Currently, `get_roshost.py` is used at every ROS-based systemd files.
With this PR, `get_roshost.py` set ROS_MASTER_URI as well as ROS_IP.
https://github.com/iory/riberry/blob/0a30224542400acdadfdddbddb9a72c5bfb579cd/ros/riberry_startup/systemd/roscore.service#L9

Without argument, do not change the original behavior.

```
$ ./get_roshost.py 
ROS_IP=192.168.97.188
```


With ROS master IP address argument, ROS_MASTER_URI is set.

```
$ ./get_roshost.py --rossetmaster 1.2.3.4
ROS_IP=192.168.97.188 ROS_MASTER_URI=http://1.2.3.4:11311
```

If argument is empty, ROS_MASTER_URI is not set.

```
$ ./get_roshost.py --rossetmaster
ROS_IP=192.168.97.188
```