### PR TITLE
Change ROS-based systemd ROS_MASTER_URI by 'systemctl set-environment' command

### DIFF
--- a/bin/run_display_information.sh
+++ b/bin/run_display_information.sh
@@ -6,4 +6,10 @@ elif [ -f /opt/ros/noetic/setup.bash ]; then
     . /opt/ros/noetic/setup.bash
 fi
 
+# Export ROS_MASTER_URI after /opt/ros/.../setup.bash
+# because ROS_MASTER_URI is set to localhost by the script.
+if [ -n "$RIBERRY_ROS_MASTER_IP" ]; then
+    export ROS_MASTER_URI=http://$RIBERRY_ROS_MASTER_IP:11311
+fi
+
 /usr/bin/python3 /usr/local/bin/display_information.py

--- a/ros/riberry_startup/scripts/get_roshost.py
+++ b/ros/riberry_startup/scripts/get_roshost.py
@@ -48,8 +48,8 @@ def get_roshost(retry=None, ros_master_ip=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='IP Address Parser')
     parser.add_argument(
-        '-r', '--rossetmaster', type=str, default=None,
-        help='ROS_MASTER_URI IP address')
+        '-', '--rossetmaster', type=str, nargs='?', const=None,
+        help='IP address to display (default: 8.8.8.8)')
     args = parser.parse_args()
 
     roshost = get_roshost(ros_master_ip=args.rossetmaster)

--- a/ros/riberry_startup/scripts/get_roshost.py
+++ b/ros/riberry_startup/scripts/get_roshost.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import socket
 import subprocess
 import time
@@ -32,14 +33,24 @@ def wait_and_get_ros_ip(retry=300):
     return None
 
 
-def get_roshost(retry=None):
+def get_roshost(retry=None, ros_master_ip=None):
     ros_ip = wait_and_get_ros_ip(retry or 300)
+    ros_script = ""
     if ros_ip:
-        return f"ROS_IP={ros_ip}"
+        ros_script += f"ROS_IP={ros_ip}"
     else:
-        return f"ROS_HOSTNAME={socket.gethostname()}.local"
+        ros_script += f"ROS_HOSTNAME={socket.gethostname()}.local"
+    if ros_master_ip is not None:
+        ros_script += f" ROS_MASTER_URI=http://{ros_master_ip}:11311"
+    return ros_script
 
 
 if __name__ == "__main__":
-    roshost = get_roshost()
+    parser = argparse.ArgumentParser(description='IP Address Parser')
+    parser.add_argument(
+        '-r', '--rossetmaster', type=str, default=None,
+        help='ROS_MASTER_URI IP address')
+    args = parser.parse_args()
+
+    roshost = get_roshost(ros_master_ip=args.rossetmaster)
     print(roshost)

--- a/ros/riberry_startup/systemd/riberry_startup.service
+++ b/ros/riberry_startup/systemd/riberry_startup.service
@@ -10,7 +10,7 @@ BindsTo=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup riberry_startup.launch --wait'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roslaunch riberry_startup riberry_startup.launch --wait'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s

--- a/ros/riberry_startup/systemd/roscore.service
+++ b/ros/riberry_startup/systemd/roscore.service
@@ -6,12 +6,14 @@ Requires=NetworkManager.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roscore'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roscore'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s
 Type=simple
 User=rock
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/ros/riberry_startup/systemd/user.service
+++ b/ros/riberry_startup/systemd/user.service
@@ -10,7 +10,7 @@ BindsTo=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roslaunch riberry_startup user.launch --wait'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roslaunch riberry_startup user.launch --wait'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
Based on https://github.com/iory/riberry/pull/123

Change ROS-based systemd's ROS_MASTER_URI by command line (and Python subprocess).

```
sudo systemctl stop riberry_startup.service
sudo systemctl set-environment RIBERRY_ROS_MASTER_IP=192.168.97.188
sudo systemctl start riberry_startup.service
```

Do not forget to call

```
sudo systemctl unset-environment RIBERRY_ROS_MASTER_IP
```

after changing RIBERRY_ROS_MASTER_IP