### PR TITLE
Add speed parameter for playing motion

### DIFF
--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -214,7 +214,7 @@ class MotionManager:
             "special_actions": special_actions
         }
 
-    def play_motion(self, motion, actions):
+    def play_motion(self, motion, actions, speed=1.0):
         """Executes a sequence of motions with safety checks and interruption handling.
 
         Returns:
@@ -224,6 +224,9 @@ class MotionManager:
         if 'joint_states' not in motion[0]:
             print("First element must have 'joint_states' key.")
             return
+        if speed == 0:
+            print("Speed cannot be zero. Setting speed to 1.0.")
+            speed = 1.0
         self.ri.servo_on()
         first_av = list(motion[0]['joint_states'].values())
         self.ri.angle_vector(first_av, 3)
@@ -246,7 +249,7 @@ class MotionManager:
                 if 'joint_states' in m:
                     av = np.array(list(m['joint_states'].values()))
                     avs.append(av)
-                    tms.append(current_time - prev_time)
+                    tms.append((current_time - prev_time) / speed)
                 prev_time = current_time
             rospy.loginfo('angle vectors')
             rospy.loginfo(f'{avs}')

--- a/riberry/teaching_manager.py
+++ b/riberry/teaching_manager.py
@@ -102,7 +102,7 @@ class TeachingManager:
             f"{len(self.marker_manager.get_markers())} markers"
         return message
 
-    def play(self, play_filepath):
+    def play(self, play_filepath, speed=1.0):
         """Plays back recorded motion
 
         Args:
@@ -126,7 +126,7 @@ class TeachingManager:
         special_actions = self.motion_manager.get_actions()
         if len(self.marker_manager.get_markers()) == 0:
             return self.motion_manager.play_motion(
-                recorded_motion, special_actions)
+                recorded_motion, special_actions, speed)
         else:
             # The entire movement is performed again after the initial posture
             # to compensate for deflection of the arm due to gravity
@@ -163,4 +163,4 @@ class TeachingManager:
                 return message
             else:
                 return self.motion_manager.play_motion(
-                    moved_motion, special_actions)
+                    moved_motion, special_actions, speed)

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -64,6 +64,7 @@ class TeachingMode(I2CBase):
         self.recording = False
         self.playing = False
         self.mode = None
+        self.speed = rospy.get_param('~speed', 1.0)
         # Button and mode callback
         rospy.Subscriber(
             "/atom_s3_button_state",
@@ -345,7 +346,7 @@ class TeachingMode(I2CBase):
 
         def play_task():
             result_message = self.teaching_manager.play(
-                self.play_file)
+                self.play_file, self.speed)
             self.additional_str = result_message
             # Automatically stop after play
             self.stop_playing()


### PR DESCRIPTION
This PR enables the playback of recorded motions at adjustable speeds.

The speed parameter can accept any non-zero value, but if it exceeds the joint speed limit, it will be adjusted to ensure it does not surpass the maximum speed.