### PR TITLE
[pairing_mode] Double click to reset pairing status

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -31,6 +31,9 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
         pairing.stopPairing();
       }
     }
+    else if (buttonState == DOUBLE_CLICK) {
+      pairing.reset();
+    }
     pairedMACs = pairing.getPairedMACAddresses();
 
     if (pairing.isPairingActive() && millis() - pairingStartTime >= 3000) {

--- a/firmware/esp_now_pairing/lib/pairing/pairing.cpp
+++ b/firmware/esp_now_pairing/lib/pairing/pairing.cpp
@@ -179,3 +179,10 @@ void Pairing::onDataRecv(const uint8_t* mac_addr, const uint8_t* data, int data_
     receivePairingData(macString, receivedData);
   }
 }
+
+void Pairing::reset() {
+  pairedMACAddresses.clear();
+  pairingDataMap.clear();
+  pendingPeers.clear();
+  setupBroadcastPeer();
+}

--- a/firmware/esp_now_pairing/lib/pairing/pairing.h
+++ b/firmware/esp_now_pairing/lib/pairing/pairing.h
@@ -21,6 +21,7 @@ public:
   void broadcastMACAddress();
   String getMyMACAddress() const;
   String getStatus() const;
+  void reset();
   static bool isPairingActive() {
     return _pairingActive;
   }


### PR DESCRIPTION
When double clicked,

Reset the following variables in Pairing class.
- pairedMACAddresses
- pairingDataMap
- pendingPeers

Then, call
- setupBroadcastPeer()