### PR TITLE
Define Role class in com/role.h and use Role class in CommunicationBase

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
@@ -5,17 +5,14 @@ Stream* CommunicationBase::_stream = nullptr;
 String CommunicationBase::requestStr = "";        // Initialize the static requestStr
 String CommunicationBase::forcedMode = "";        // Initialize the static forcedMode
 String CommunicationBase::selectedModesStr = "";  // Initialize the static selectedModesStr
-String CommunicationBase::main_or_secondary = "";
+Role CommunicationBase::role;
 
-CommunicationBase::CommunicationBase(PrimitiveLCD& lcd,
-                                     ButtonManager& button,
-                                     Pairing& pairing,
-                                     Stream* stream,
-                                     String main_or_secondary)
+CommunicationBase::CommunicationBase(
+        PrimitiveLCD& lcd, ButtonManager& button, Pairing& pairing, Stream* stream, Role role)
     : lcd(lcd), button_manager(button), pairing(pairing), receiveEventEnabled(true) {
     instance = this;
     setStream(stream);
-    this->main_or_secondary = main_or_secondary;
+    this->role = role;
 }
 
 void CommunicationBase::setStream(Stream* stream) { _stream = stream; }
@@ -113,7 +110,7 @@ void CommunicationBase::receiveEvent(int howMany) {
             break;
 
         case GET_PAIRING_TYPE:
-            _stream->write(main_or_secondary.c_str(), main_or_secondary.length());
+            _stream->write(getRoleStr(role).c_str(), getRoleStr(role).length());
             break;
 
         case PAIRING_IP_REQUEST: {

--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
@@ -2,9 +2,9 @@
 
 CommunicationBase* CommunicationBase::instance = nullptr;
 Stream* CommunicationBase::_stream = nullptr;
-String CommunicationBase::requestStr = "";        // Initialize the static requestStr
-String CommunicationBase::forcedMode = "";        // Initialize the static forcedMode
-String CommunicationBase::selectedModesStr = "";  // Initialize the static selectedModesStr
+String CommunicationBase::requestStr = "";
+String CommunicationBase::forcedMode = "";
+String CommunicationBase::selectedModesStr = "";
 Role CommunicationBase::role;
 
 CommunicationBase::CommunicationBase(
@@ -34,23 +34,23 @@ int CommunicationBase::splitString(const String& input,
 
     while (true) {
         int end = input.indexOf(delimiter, start);
-        if (end == -1) {  // 区切り文字が見つからない場合
+        if (end == -1) {  // If the delimiter is not found
             if (index < maxParts) {
-                String part = input.substring(start);  // 最後の部分を取得
-                output[index] = strdup(part.c_str());  // strdupで動的メモリにコピー
+                String part = input.substring(start);
+                output[index] = strdup(part.c_str());
                 index++;
             }
             break;
         }
         if (index < maxParts) {
-            String part = input.substring(start, end);  // 区切り文字までの部分を取得
-            output[index] = strdup(part.c_str());       // strdupで動的メモリにコピー
+            String part = input.substring(start, end);
+            output[index] = strdup(part.c_str());
             index++;
         }
-        start = end + 1;  // 次の部分へ進む
+        start = end + 1;
     }
 
-    return index;  // 分割された部分の数を返す
+    return index;  // Returns the number of divided portions
 }
 
 void CommunicationBase::receiveEvent(int howMany) {
@@ -193,12 +193,11 @@ void CommunicationBase::requestEvent() {
     uint8_t sentStr[100];
     sentStr[0] = (uint8_t)instance->button_manager.getButtonState();
     const char* modeData = requestStr.c_str();
-    // sentStr[1]以降にstrDataをコピー (長さを確認)
-    size_t strLen = strlen(modeData);  // requestStrの長さを取得
+    size_t strLen = strlen(modeData);
     if (strLen > 98) {
-        strLen = 98;  // バッファオーバーフローを防ぐため最大98バイトに制限
+        strLen = 98;  // Limited to a maximum of 98 bytes to prevent buffer overflow
     }
-    memcpy(&sentStr[1], modeData, strLen);  // sentStr[1]以降にstrDataをコピー
+    memcpy(&sentStr[1], modeData, strLen);
 
     _stream->write(sentStr, strLen + 1);
     instance->button_manager.notChangedButtonState();

--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.h
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.h
@@ -7,6 +7,7 @@
 
 #include "packet.h"
 #include "pairing.h"
+#include "role.h"
 
 class CommunicationBase {
 public:
@@ -23,7 +24,7 @@ public:
                       ButtonManager& button,
                       Pairing& pairing,
                       Stream* stream,
-                      String main_or_secondary = "Main");
+                      Role role = Role::Main);
 
     /**
      * @brief Creates and starts the I2C communication task on the specified
@@ -49,6 +50,7 @@ public:
 
     static String forcedMode;
     static String selectedModesStr;
+    static Role role;
 
     static void setStream(Stream* stream);
     Stream* getStream() const;
@@ -64,7 +66,7 @@ private:
     ButtonManager& button_manager;      /**< Reference to the ButtonManager object
                                            for button interactions. */
     Pairing& pairing;
-    static String main_or_secondary;
+
     unsigned long lastReceiveTime = 0; /**< Last time data was received over I2C. */
     const unsigned long receiveTimeout =
             15000; /**< Timeout duration for I2C communication (15 seconds). */

--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.h
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.h
@@ -1,7 +1,7 @@
 #ifndef COMMUNICATION_BASE_H
 #define COMMUNICATION_BASE_H
 
-#include <WireSlave.h>  // for i2c
+#include <WireSlave.h>
 #include <button_manager.h>
 #include <primitive_lcd.h>
 
@@ -13,33 +13,14 @@ class CommunicationBase {
 public:
     virtual ~CommunicationBase() = default;
 
-    /**
-     * @brief Constructor for CommunicationBase, initializes the I2C class with
-     * references to the LCD and Button objects.
-     *
-     * @param lcd Reference to the PrimitiveLCD object.
-     * @param button Reference to the ButtonManager object.
-     */
     CommunicationBase(PrimitiveLCD& lcd,
                       ButtonManager& button,
                       Pairing& pairing,
                       Stream* stream,
                       Role role = Role::Main);
 
-    /**
-     * @brief Creates and starts the I2C communication task on the specified
-     * core.
-     *
-     * @param xCoreID Core ID to run the task on (0 or 1).
-     */
     void createTask(uint8_t xCoreID);
 
-    /**
-     * @brief Checks whether the I2C communication has timed out.
-
-     *
-     * @return true if the communication has timed out, false otherwise.
-     */
     bool checkTimeout();
 
     int splitString(const String& input, char delimiter, char* output[], int maxParts);
@@ -59,54 +40,29 @@ private:
     static Stream* _stream;
 
     bool receiveEventEnabled;
-    static CommunicationBase* instance; /**< Singleton instance of CommunicationBase for managing
-                                           callbacks. */
-    PrimitiveLCD& lcd;                  /**< Reference to the PrimitiveLCD object for displaying
-                                           information. */
-    ButtonManager& button_manager;      /**< Reference to the ButtonManager object
-                                           for button interactions. */
+    static CommunicationBase* instance;
+    PrimitiveLCD& lcd;
+    ButtonManager& button_manager;
     Pairing& pairing;
 
-    unsigned long lastReceiveTime = 0; /**< Last time data was received over I2C. */
-    const unsigned long receiveTimeout =
-            15000; /**< Timeout duration for I2C communication (15 seconds). */
+    unsigned long lastReceiveTime = 0;
+    const unsigned long receiveTimeout = 15000;
 
-    static constexpr uint8_t jpegPacketHeader[3] = {
-            0xFF, 0xD8, 0xEA};                    /**< JPEG image packet header identifier. */
-    static constexpr uint8_t qrCodeHeader = 0x02; /**< QR code packet header identifier. */
-    static constexpr uint8_t forceModeHeader[3] = {
-            0xFF, 0xFE, 0xFD}; /**< Force mode packet header identifier. */
-    static constexpr uint8_t selectedModesHeader[3] = {
-            0xFC, 0xFB, 0xFA}; /**< Selected modes packet header identifier. */
+    static constexpr uint8_t jpegPacketHeader[3] = {0xFF, 0xD8, 0xEA};
+    static constexpr uint8_t qrCodeHeader = 0x02;
+    static constexpr uint8_t forceModeHeader[3] = {0xFF, 0xFE, 0xFD};
+    static constexpr uint8_t selectedModesHeader[3] = {0xFC, 0xFB, 0xFA};
 
     static String requestStr; /**< String to be sent on I2C request. */
 
-    /**
-     * @brief Updates the last receive time to the current time.
-     */
     void updateLastReceiveTime();
 
-    /**
-     * @brief Called when data is received over communication.
-     *
-     * @param howMany Number of bytes received.
-     */
     static void receiveEvent(int howMany);
     static void handleJpegPacket(const String& str);
     static void handleQrCodePacket(const String& str);
     static void handleForceModePacket(const String& str);
     static void handleSelectedModePacket(const String& str);
-
-    /**
-     * @brief Called when the master requests data from the I2C or UART slave.
-     */
     static void requestEvent();
-
-    /**
-     * @brief The task that handles communication in the background.
-     *
-     * @param parameter Task parameter (unused).
-     */
     static void task(void* parameter);
 };
 

--- a/firmware/atom_s3_i2c_display/lib/com/role.h
+++ b/firmware/atom_s3_i2c_display/lib/com/role.h
@@ -1,0 +1,17 @@
+enum class Role { Main, Secondary };
+
+static String getRoleStr(Role role) {
+    String roleStr;
+    switch (role) {
+        case Role::Main:
+            roleStr = "Main";
+            break;
+        case Role::Secondary:
+            // Shorten word for AtomS3 small display
+            roleStr = "Second";
+            break;
+        default:
+            roleStr = "";
+    }
+    return roleStr;
+}

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -11,7 +11,7 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     ButtonState buttonState;
     uint8_t xCoreID = 0;
     preferences.begin("pairing_mode", false);
-    preferences.getBytes("role", &currentRole, sizeof(Role));
+    preferences.getBytes("role", &com.role, sizeof(Role));
 
     pairing.stopPairing();
     pairing.startBackgroundTask(xCoreID);
@@ -37,12 +37,12 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
                 pairing.stopPairing();
             }
         } else if (buttonState == DOUBLE_CLICK) {
-            if (currentRole == Role::Main) {
-                currentRole = Role::Secondary;
-                preferences.putBytes("role", &currentRole, sizeof(Role));
+            if (com.role == Role::Main) {
+                com.role = Role::Secondary;
+                preferences.putBytes("role", &com.role, sizeof(Role));
             } else {
-                currentRole = Role::Main;
-                preferences.putBytes("role", &currentRole, sizeof(Role));
+                com.role = Role::Main;
+                preferences.putBytes("role", &com.role, sizeof(Role));
             }
             pairing.reset();
         }
@@ -61,13 +61,9 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
         } else {
             displayText += Color::Background::RED + "Pairing OFF\n" + Color::Background::RESET;
         }
-        displayText += "2tap ";
-        if (currentRole == Role::Main) {
-            displayText += "Role: Main\n";
-        } else {
-            displayText += "Role: Second\n";
-        }
-        displayText += "\nMy name:\n" + fancyMacAddress(pairing.getMyMACAddress().c_str()) + "\n";
+        displayText += "2tap Role: ";
+        displayText += getRoleStr(com.role);
+        displayText += "\n\nMy name:\n" + fancyMacAddress(pairing.getMyMACAddress().c_str()) + "\n";
         if (!pairedMACs.empty()) {
             displayText += "\nPaired devices:\n";
             for (const auto &mac : pairedMACs) {

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.h
@@ -8,8 +8,6 @@
 #include <pairing.h>
 #include <primitive_lcd.h>
 
-enum class Role { Main, Secondary };
-
 class PairingMode : public Mode {
 public:
     PairingMode(ButtonManager &button_manager, Pairing &pairing);
@@ -22,7 +20,6 @@ private:
     ButtonManager &button_manager;
     Pairing &pairing;
     Preferences preferences;
-    Role currentRole = Role::Main;
 };
 
 #endif  // PAIRING_MODE_H

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -18,12 +18,6 @@ ButtonManager button_manager;
 PrimitiveLCD lcd;
 Pairing pairing;
 
-#if defined(PAIRING_TYPE) && PAIRING_TYPE == 0
-const char *main_or_secondary = "Main";
-#else
-const char *main_or_secondary = "Secondary";
-#endif
-
 #ifdef ATOM_S3
     #ifdef I2C_ADDR
 static constexpr int i2c_slave_addr = I2C_ADDR;
@@ -40,14 +34,14 @@ static constexpr int scl_pin = 39;
     #endif  // end of USE_GROVE
 
     #ifdef USE_USB_SERIAL
-CommunicationBase comm(lcd, button_manager, pairing, &USBSerial, main_or_secondary);
+CommunicationBase comm(lcd, button_manager, pairing, &USBSerial);
     #else
         #include <WireSlave.h>
-CommunicationBase comm(lcd, button_manager, pairing, &WireSlave, main_or_secondary);
+CommunicationBase comm(lcd, button_manager, pairing, &WireSlave);
     #endif
 
 #elif USE_M5STACK_BASIC
-CommunicationBase comm(lcd, button_manager, pairing, &Serial, main_or_secondary);
+CommunicationBase comm(lcd, button_manager, pairing, &Serial);
 #endif
 
 // Define all available modes


### PR DESCRIPTION
This PR does not change the behavior of pairing processes.

Contents:
- Define Role class in com/role.h
- use `Role role` instead of `String main_or_secondary` in CommunicationBase
- Define `String getRoleStr (Role role)` function
- Remove unused comments