### PR TITLE
CommunicationBase send/receive pairing info only in Pairing Mode

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.h
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.h
@@ -32,6 +32,8 @@ public:
     static String forcedMode;
     static String selectedModesStr;
     static Role role;
+    void startPairing() { pairingEnabled = true; }
+    void stopPairing() { pairingEnabled = false; }
 
     static void setStream(Stream* stream);
     Stream* getStream() const;
@@ -44,6 +46,7 @@ private:
     PrimitiveLCD& lcd;
     ButtonManager& button_manager;
     Pairing& pairing;
+    static bool pairingEnabled;
 
     unsigned long lastReceiveTime = 0;
     const unsigned long receiveTimeout = 15000;

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -3,8 +3,8 @@
 #include <pairing_mode.h>
 #include <string_utils.h>
 
-PairingMode::PairingMode(ButtonManager &button_manager, Pairing &pairing)
-    : Mode("PairingMode"), button_manager(button_manager), pairing(pairing) {}
+PairingMode::PairingMode(ButtonManager &button_manager, Pairing &pairing, CommunicationBase &com)
+    : Mode("PairingMode"), button_manager(button_manager), pairing(pairing), com(com) {}
 
 void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     prevStr = "";
@@ -47,6 +47,7 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
                     preferences.putBytes("role", &com.role, sizeof(Role));
                 }
                 pairing.reset();
+                pairing.setupBroadcastPeer();
             }
         }
 
@@ -87,10 +88,12 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
 void PairingMode::suspendTask() {
     pairing.stopBackgroundTask();
     Mode::suspendTask();
+    com.stopPairing();
+    pairing.reset();
 }
 
 void PairingMode::resumeTask() {
-    unsigned long pairingStartTime = 0;
     pairing.resumeBackgroundTask();
     Mode::resumeTask();
+    com.startPairing();
 }

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.h
@@ -10,7 +10,7 @@
 
 class PairingMode : public Mode {
 public:
-    PairingMode(ButtonManager &button_manager, Pairing &pairing);
+    PairingMode(ButtonManager &button_manager, Pairing &pairing, CommunicationBase &com);
     void suspendTask() override;
     void resumeTask() override;
 
@@ -18,6 +18,7 @@ private:
     void task(PrimitiveLCD &lcd, CommunicationBase &com) override;
 
     ButtonManager &button_manager;
+    CommunicationBase &com;
     Pairing &pairing;
     Preferences preferences;
 };

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -53,7 +53,7 @@ DisplayOdomMode display_odom_mode;
 ServoControlMode servo_control_mode;
 PressureControlMode pressure_control_mode;
 TeachingMode teaching_mode;
-PairingMode pairing_mode(button_manager, pairing);
+PairingMode pairing_mode(button_manager, pairing, comm);
 const std::vector<Mode *> allModes = {
         &display_information_mode,   &display_qrcode_mode, &display_image_mode,
         &display_battery_graph_mode, &display_odom_mode,   &servo_control_mode,

--- a/firmware/esp_now_pairing/lib/pairing/pairing.cpp
+++ b/firmware/esp_now_pairing/lib/pairing/pairing.cpp
@@ -200,5 +200,4 @@ void Pairing::reset() {
     pairingDataMap.clear();
     pendingPeers.clear();
     mutex_.unlock();
-    setupBroadcastPeer();
 }


### PR DESCRIPTION
If `CommunicationBase` send/receive pairing information outside of `Pairing mode`, it leads to unexpected behavior.
