### PR TITLE
Use resume/suspend instead of start/stop for pairing task

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -91,7 +91,6 @@ void PairingMode::suspendTask() {
 
 void PairingMode::resumeTask() {
     unsigned long pairingStartTime = 0;
-    uint8_t xCoreID = 1;
-    pairing.startBackgroundTask(xCoreID);
+    pairing.resumeBackgroundTask();
     Mode::resumeTask();
 }

--- a/firmware/esp_now_pairing/lib/pairing/pairing.h
+++ b/firmware/esp_now_pairing/lib/pairing/pairing.h
@@ -40,8 +40,13 @@ public:
 
     void stopBackgroundTask() {
         if (taskHandle != nullptr) {
-            vTaskDelete(taskHandle);
-            taskHandle = nullptr;
+            vTaskSuspend(taskHandle);
+        }
+    }
+
+    void resumeBackgroundTask() {
+        if (taskHandle != nullptr) {
+            vTaskResume(taskHandle);
         }
     }
 


### PR DESCRIPTION
This will fix the following errors.

```
Guru Meditation Error: Core  1 panic'ed (StoreProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x40382fac  PS      : 0x00060a33  A0      : 0x8038322d  A1      : 0x3fcf46e0  
A2      : 0x3fca2744  A3      : 0x3fcb0868  A4      : 0x00000001  A5      : 0x000000b0  
A6      : 0x00000018  A7      : 0x00000008  A8      : 0x00000000  A9      : 0x0000001c  
A10     : 0x3fcb08d0  A11     : 0x00000017  A12     : 0x3fcb08d8  A13     : 0x3fcb09e0  
A14     : 0x00000005  A15     : 0x00000000  SAR     : 0x0000001b  EXCCAUSE: 0x0000001d  
EXCVADDR: 0x0000000d  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffffb  


Backtrace: 0x40382fa9:0x3fcf46e0 0x4038322a:0x3fcf4700 0x40383348:0x3fcf4720 0x40378412:0x3fcf4740 0x403784b5:0x3fcf4770 0x403784e3:0x3fcf4790 0x40383685:0x3fcf47b0 0x4200f5cb:0x3fcf47d0 0x4200f63c:0x3fcf4810 0x4200f897:0x3fcf4830 0x4200f9a9:0x3fcf4850 0x4200e299:0x3fcf4870 0x4200c7c4:0x3fcf4920




ELF file SHA256: ce94025074456bf2

Rebooting...
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x28 (SPI_FAST_FLASH_BOOT)
Saved PC:0x420928da
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x4bc
load:0x403c9700,len:0xbd8
load:0x403cc700,len:0x2a0c
entry 0x403c98d0
```

```
CORRUPT HEAP: Bad head at 0x3fcadcd0. Expected 0xabba1234 got 0xGuru Meditation Error: Core  1 panic'ed (Double exception). 

Core  1 register dump:
PC      : 0x4037cd66  PS      : 0x00040136  A0      : 0x820989cc  A1      : 0x3fcae890  
A2      : 0x00040136  A3      : 0x00040026  A4      : 0x000000ff  A5      : 0x0000ff00  
A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x3fcae950  A9      : 0x00000000  
A10     : 0x3fcae95c  A11     : 0x00000000  A12     : 0x3fcae930  A13     : 0x3fcae95c  
A14     : 0x00060520  A15     : 0x00000001  SAR     : 0x00000020  EXCCAUSE: 0x00000002  
EXCVADDR: 0x00000000  LBEG    : 0x400554b9  LEND    : 0x400554dd  LCOUNT  : 0x8202348c  


Backtrace: 0x4037cd63:0x3fcae890 0x420989c9:0x3fcaed80 0x00060b1d:0x3fcaed80 |<-CORRUPTED




ELF file SHA256: 5694cab9b5f453f1

Rebooting...
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x28 (SPI_FAST_FLASH_BOOT)
Saved PC:0x420928ba
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x4bc
load:0x403c9700,len:0xbd8
load:0x403cc700,len:0x2a0c
entry 0x403c98d0
```

```
assert failed: block_merge_prev heap_tlsf.c:344 (block_is_free(prev) && "prev block is not free though marked as such")

Backtrace: 0x40377aee:0x3fcf4790 0x4037cb59:0x3fcf47b0 0x40383665:0x3fcf47d0 0x4038278d:0x3fcf4900 0x40383158:0x3fcf4920 0x40383286:0x3fcf4940 0x40378345:0x3fcf4960 0x40383695:0x3fcf4980 0x4200f555:0x3fcf49a0 0x4200f565:0x3fcf49c0 0x4200e3a1:0x3fcf49e0 0x4200c818:0x3fcf4a90

ELF file SHA256: 1a29bb3de2e91849

Rebooting...
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x28 (SPI_FAST_FLASH_BOOT)
Saved PC:0x4209293e
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x4bc
load:0x403c9700,len:0xbd8
load:0x403cc700,len:0x2a0c
entry 0x403c98d0
```