### PR TITLE
Publish IP address after pairing in PairingMode

### DIFF
--- a/riberry/esp_now_pairing.py
+++ b/riberry/esp_now_pairing.py
@@ -16,7 +16,6 @@ Role._value2member_map_["Second"] = Role.Secondary
 def is_valid_role(role_string):
     return role_string in Role._value2member_map_
 
-
 def print_throttle(interval, *args, **kwargs):
     current_time = time.time()
     if not hasattr(print_throttle, 'last_print_time'):
@@ -25,79 +24,83 @@ def print_throttle(interval, *args, **kwargs):
         print(*args, **kwargs)
         print_throttle.last_print_time = current_time
 
-
-class ESPNowPairing:
-    def __init__(self):
-        self.pairing_info = None  # e.g. "8.8.8.8"
-        self.device_type = None
-
-    # com is both USB and I2C
-    def detect_device_type(self, com):
-        while True:
-            # Clear buffer to avoid mixed receive data like 'MainSecond'
-            com.reset_input_buffer()
-            com.write([PacketType.GET_PAIRING_TYPE])
-            time.sleep(0.1)
-            packet = com.read()
-            if packet == b'':
-                print_throttle(1.0, "Waiting for initial packet from pairing device...")
+# com is both USB and I2C
+def get_role(com):
+    while True:
+        # Clear buffer to avoid mixed receive data like 'MainSecond'
+        com.reset_input_buffer()
+        com.write([PacketType.GET_PAIRING_TYPE])
+        time.sleep(0.1)
+        packet = com.read()
+        if packet == b'':
+            print_throttle(1.0, "Waiting for initial packet from pairing device...")
+        else:
+            if packet is None:
+                print("Failed to get packet")
+                return None
+            role_string = packet.decode().strip()
+            if is_valid_role(role_string):
+                role = Role(role_string)
+                print(f"[{role.value}] Pairing device is connected")
+                return role
             else:
-                role_string = packet.decode().strip()
-                if is_valid_role(role_string):
-                    device_type = Role(role_string)
-                    print(f"[{device_type.value}] Pairing device is connected")
-                    return {'com': com, 'device_type': device_type}
-                else:
-                    print(f"Unknown device type: {role_string}")
-                break
-            time.sleep(0.1)
-        return None
+                print(f"Unknown device type: {role_string}")
+            break
+        time.sleep(0.1)
+    return None
 
-    def find_USB_pairing_devices(self, usb_ports, baudrate=115200):
-        ret = []
-        ports = usb_ports
-        if len(ports) == 0:
-            print("Cannot find USB devices")
-            return ret
-        for port in ports:
-            try:
-                com = UARTBase(port, baudrate)
-                print(f"Connect to USB device: {port}")
-                dev = self.detect_device_type(com)
-                if dev is not None:
-                    ret.append(dev)
-            except Exception as e:
-                print(f"Error: {e}")
-                return ret
+def find_USB_pairing_devices(usb_ports, baudrate=115200):
+    ret = []
+    ports = usb_ports
+    if len(ports) == 0:
+        print("Cannot find USB devices")
         return ret
-
-    def find_I2C_pairing_devices(self, device, bus):
-        ret = []
+    for port in ports:
         try:
-            com = I2CBase(device, bus)
-            print(f"Connect to I2C device: {device}")
-            dev = self.detect_device_type(com)
-            if dev is not None:
-                ret = dev
+            com = UARTBase(port, baudrate)
+            print(f"Connect to USB device: {port}")
+            role = get_role(com)
+            if role is not None:
+                ret.append({"com": com, "role": role})
         except Exception as e:
             print(f"Error: {e}")
             return ret
-        return ret
+    return ret
 
-    def send_string(self, com, string):
+def find_I2C_pairing_devices(device, bus):
+    ret = []
+    try:
+        com = I2CBase(device, bus)
+        print(f"Connect to I2C device: {device}")
+        role = get_role(com)
+        if role is not None:
+            ret.append({"com": com, "role": role})
+    except Exception as e:
+        print(f"Error: {e}")
+        return ret
+    return ret
+
+def pairing_info_to_packet(pairing_info):
+    packet = [PacketType.SET_IP_REQUEST] + list(map(int, pairing_info.split('.')))
+    return packet
+
+def packet_to_pairing_info(packet):
+    pairing_info = '.'.join(map(str, list(packet)))
+    return pairing_info
+
+
+class ESPNowPairing:
+    def __init__(self, com, role):
+        self.com = com
+        self.role = role
+        self.pairing_info = None  # e.g. "8.8.8.8"
+
+    def send_string(self, string):
         """Send IP address to ESP32"""
         try:
-            com.write(string)
+            self.com.write(string)
         except Exception as e:
             print(f"Send error: {e}")
-
-    def pairing_info_to_packet(self, pairing_info):
-        packet = [PacketType.SET_IP_REQUEST] + list(map(int, self.pairing_info.split('.')))
-        return packet
-
-    def packet_to_pairing_info(self, packet):
-        pairing_info = '.'.join(map(str, list(packet)))
-        return pairing_info
 
     def set_pairing_info(self, pairing_info):
         self.pairing_info = pairing_info
@@ -105,35 +108,33 @@ class ESPNowPairing:
     def get_pairing_info(self):
         return self.pairing_info
 
-    def send_pairing_info(self, com):
-        packet = self.pairing_info_to_packet(self.pairing_info)
-        self.send_string(com, packet)
+    def send_pairing_info(self):
+        packet = pairing_info_to_packet(self.pairing_info)
+        self.send_string(packet)
 
-    def receive_pairing_info(self, com):
+    def receive_pairing_info(self):
         try:
             while True:
-                com.reset_input_buffer()
-                com.write([PacketType.PAIRING_IP_REQUEST])
+                self.com.reset_input_buffer()
+                self.com.write([PacketType.PAIRING_IP_REQUEST])
                 time.sleep(0.1)
-                packet = com.read()
+                packet = self.com.read()
                 if packet == b'':
-                    print_throttle(1.0, f"[{self.device_type.value}] Waiting for pairing info ...")
+                    print_throttle(1.0, f"[{Role.Secondary.value}] Waiting for pairing info ...")
                 elif len(packet) == 4:
-                    pairing_info = self.packet_to_pairing_info(packet)
+                    pairing_info = packet_to_pairing_info(packet)
                     self.pairing_info = pairing_info
-                    print(f"[{self.device_type.value}] Receive pairing info: {pairing_info}")
+                    print(f"[{Role.Secondary.value}] Receive pairing info: {pairing_info}")
                     return
                 time.sleep(0.1)
         except Exception as e:
             print(f"Error: {e}")
 
-    def pairing(self, pairing_device):
-        com = pairing_device['com']
-        self.device_type = pairing_device['device_type']
-        print(f'[{self.device_type.value}] Pairing start.')
-        if self.device_type == Role.Main:
-            print(f"[{self.device_type.value}] Send pairing info: {self.pairing_info}")
-            self.send_pairing_info(com)
-        elif self.device_type == Role.Secondary:
-            print(f"[{self.device_type.value}] Start receive_pairing_info")
-            self.receive_pairing_info(com)
+    def pairing(self):
+        print(f'[{self.role.value}] Pairing start.')
+        if self.role == Role.Main:
+            print(f"[{self.role.value}] Send pairing info: {self.pairing_info}")
+            self.send_pairing_info()
+        elif self.role == Role.Secondary:
+            print(f"[{self.role.value}] Start receive_pairing_info")
+            self.receive_pairing_info()


### PR DESCRIPTION
Pairing mode can be used with display_information.py

For example, the following devices can be paired with each other

- Laptop uses AtomS3 with USB
  ```
  $ USE_USB_SERIAL=1 pio run -t upload
  $ python3 bin/display_information.py
  ```

- Radxa uses AtomS3 with I2C
  ``` 
  $ pio run -t upload 
  $ python3 bin/display_information.py
  ```