### PR TITLE
CommunicationBase returns dummy value when unexpected packets arrive

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -355,7 +355,12 @@ class DisplayInformation:
                             esp_now_pairing.set_pairing_info(get_ip_address())
                         esp_now_pairing.pairing()
                         if esp_now_pairing.role == Role.Secondary:
-                            pairing_info = esp_now_pairing.get_pairing_info()
+                            new_pairing_info = esp_now_pairing.get_pairing_info()
+                            if new_pairing_info == "255.255.255.255":
+                                pairing_info = None
+                                print("pairing failed")
+                            else:
+                                pairing_info = new_pairing_info
                 if button_count == 2:
                     pairing_info = None
             else:

--- a/riberry/esp_now_pairing.py
+++ b/riberry/esp_now_pairing.py
@@ -45,6 +45,7 @@ def get_role(com):
                 return role
             else:
                 print(f"Unknown device type: {role_string}")
+                return None
             break
         time.sleep(0.1)
     return None


### PR DESCRIPTION
To prevent the display_information_mode.py process from getting stuck, pairing mode now always returns a value