### PR TITLE
Print pairing mode status at the bottom of LCD

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -74,6 +74,7 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
                 displayText += fancyMacAddress(mac.c_str()) + "\n";
             }
         }
+        displayText += "\n" + pairing.getStatus();
 
         if (!compareIgnoringEscapeSequences(prevStr, displayText)) {
             prevStr = displayText;


### PR DESCRIPTION
Note
Sometimes text goes outside of the LCD