### PR TITLE
Fix heap_caps_free assertion by increasing task stack size

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/mode/mode.h
+++ b/firmware/atom_s3_i2c_display/lib/mode/mode.h
@@ -65,7 +65,10 @@ public:
 
     void createTask(uint8_t xCoreID, PrimitiveLCD& lcd, CommunicationBase& com) {
         auto* params = new std::tuple<Mode*, PrimitiveLCD*, CommunicationBase*>(this, &lcd, &com);
-        xTaskCreatePinnedToCore(this->startTaskImpl, getModeName().c_str(), 2048, params, 1,
+        // Increasing the stack size (2048 -> 4096) prevents the following assertion:
+        // assert failed: heap_caps_free heap_caps.c:381 (heap != NULL && "free() target pointer is
+        // outside heap areas")
+        xTaskCreatePinnedToCore(this->startTaskImpl, getModeName().c_str(), 8192, params, 1,
                                 &taskHandle, xCoreID);
     }
 

--- a/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.cpp
+++ b/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.cpp
@@ -139,9 +139,8 @@ void ModeManager::addSelectedMode(Mode &mode) { selectedModes.push_back(&mode); 
 void ModeManager::deleteSelectedModes() {
     // Before deleting modes, all modes must be suspended
     for (int i = 0; i < selectedModes.size(); i++) {
-        if (!selectedModes[i]->isTaskSuspended()) {
-            selectedModes[i]->suspendTask();
-        }
+        selectedModes[i]->suspendTask();
+        selectedModes[i]->waitForTaskSuspended();
     }
     selectedModes.clear();
 }


### PR DESCRIPTION
Original error (AtomS3 automatically rebooted)

```
assert failed: heap_caps_free heap_caps.c:381 (heap != NULL && "free() target pointer is outside heap areas")

assert failed: heap_caps_free heap_caps.c:381 (heap != NULL && "free() target pointer is outside heap areas")


Backtrace: 0x4037d0a7:0x3fca3340 0x40377f75:0x3fca3360 0x4201f66b:0x3fca3390 0x4201f2c4:0x3fca33c0 0x4201f2e5:0x3fca33e0 0x4201eef6:0x3fca3400




ELF file SHA256: 972f2fccab6cbd79

Rebooting...
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x28 (SPI_FAST_FLASH_BOOT)
Saved PC:0x42093b26
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x4bc
load:0x403c9700,len:0xbd8
load:0x403cc700,len:0x2a0c
entry 0x403c98d0