### PR TITLE
Change PairingMode user interface

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -150,7 +150,9 @@ def try_init_ros():
                 mode_pub.publish(String(data=atom_s3_mode))
                 button_pub.publish(Int32(data=button_count))
                 if pairing_info is not None:
+                    # This is dangerous operation, so publish once
                     pairing_info_pub.publish(String(data=pairing_info))
+                    pairing_info = None
                 button_count = 0
                 ros_display_image_param = rospy.get_param("display_image", None)
                 if battery_percentage is not None:
@@ -361,8 +363,10 @@ class DisplayInformation:
                                 print("pairing failed")
                             else:
                                 pairing_info = new_pairing_info
+               # Double tap to restore ROS_MASTER_URI
+               # to the IP address of this computer
                 if button_count == 2:
-                    pairing_info = None
+                    pairing_info = get_ip_address()
             else:
                 time.sleep(0.1)
 

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -90,7 +90,6 @@ void PairingMode::suspendTask() {
     pairing.stopBackgroundTask();
     Mode::suspendTask();
     com.stopPairing();
-    pairing.reset();
 }
 
 void PairingMode::resumeTask() {


### PR DESCRIPTION
- Do not reset pairing state when LCD long tap
- Double tap to restore ROS_MASTER_URI to the IP address of display_information.py computer