### PR TITLE
Removed delay, which was necessary to avoid packet mixing

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.cpp
+++ b/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.cpp
@@ -126,7 +126,6 @@ void ModeManager::changeMode(int suspend_mode_index, int resume_mode_index) {
     instance->lcd.drawBlack();
     instance->lcd.printColorText("Wait for mode switch ...\n");
     instance->lcd.setTextSize(DEFAULT_TEXT_SIZE);
-    vTaskDelay(pdMS_TO_TICKS(1000));
     instance->lcd.resetLcdData();
     // Resume
     comm.setRequestStr(selectedModes[resume_mode_index]->getModeName());


### PR DESCRIPTION
### Background

- When this program was added, PACKET_HEADER did not exist.
- So, packets were mixed during the mode transition.
- As a result, data from the previous mode was sometimes displayed in the next mode during mode transitions.
- To avoid this, a certain time delay was put in

### Now

PACKET_HEADER has been introduced and packets are not mixed, so this delay can be eliminated