### PR TITLE
Use createTask instead of resumeTask

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/mode/mode.h
+++ b/firmware/atom_s3_i2c_display/lib/mode/mode.h
@@ -87,7 +87,7 @@ public:
         vTaskDelete(NULL);
     }
 
-    void createTask(uint8_t xCoreID, PrimitiveLCD& lcd, CommunicationBase& com) {
+    virtual void createTask(uint8_t xCoreID, PrimitiveLCD& lcd, CommunicationBase& com) {
         running = true;
         auto* params = new std::tuple<Mode*, PrimitiveLCD*, CommunicationBase*>(this, &lcd, &com);
         // Increasing the stack size (2048 -> 4096) prevents the following assertion:

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -93,9 +93,9 @@ void PairingMode::deleteTask() {
     WiFi.disconnect(true);
 }
 
-void PairingMode::resumeTask() {
+void PairingMode::createTask(uint8_t xCoreID, PrimitiveLCD &lcd, CommunicationBase &com) {
     WiFi.reconnect();
     pairing.createTask(1);
-    Mode::resumeTask();
+    Mode::createTask(1, lcd, com);
     com.startPairing();
 }

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.h
@@ -12,7 +12,7 @@ class PairingMode : public Mode {
 public:
     PairingMode(ButtonManager &button_manager, Pairing &pairing, CommunicationBase &com);
     void deleteTask() override;
-    void resumeTask() override;
+    void createTask(uint8_t xCoreID, PrimitiveLCD &lcd, CommunicationBase &com) override;
 
 private:
     void task(PrimitiveLCD &lcd, CommunicationBase &com) override;


### PR DESCRIPTION
Without this PR, `PairingMode` task does not start, because `ModeManager` uses createTask/deleteTask instead of resumeTask/suspendTask.
https://github.com/iory/riberry/pull/159