### PR TITLE
Remove global namespace for change_systemd_rosmaster.py to change the namespace

### DIFF
--- a/ros/riberry_startup/launch/atoms3_button_state_publisher.launch
+++ b/ros/riberry_startup/launch/atoms3_button_state_publisher.launch
@@ -16,8 +16,8 @@
           pkg="riberry_startup" type="i2c_button_state_publisher"
           respawn="true"
           output="screen">
-      <remap from="/i2c_button_state" to="/atom_s3_button_state" />
-      <remap from="/i2c_mode" to="/atom_s3_mode" />
+      <remap from="/i2c_button_state" to="atom_s3_button_state" />
+      <remap from="/i2c_mode" to="atom_s3_mode" />
     </node>
   </group>
 

--- a/ros/riberry_startup/launch/module_llm_speech_to_text.launch
+++ b/ros/riberry_startup/launch/module_llm_speech_to_text.launch
@@ -1,8 +1,8 @@
 <!-- Mainly copied from ros_speech_recognition/launch/speech_recognition.launch -->
 
 <launch>
-  <arg name="audio_topic" default="/audio" />
-  <arg name="audio_info_topic" default="/audio_info" />
+  <arg name="audio_topic" default="audio" />
+  <arg name="audio_info_topic" default="audio_info" />
 
   <!-- audio capture from microphone -->
   <node name="audio_capture" pkg="audio_capture" type="audio_capture"
@@ -32,7 +32,7 @@
         pkg="riberry_startup" type="speech_to_text.py"
         respawn="true"
         output="screen">
-    <remap from="audio" to="/webrtcvad_ros/speech_audio"  />
+    <remap from="audio" to="webrtcvad_ros/speech_audio"  />
     <remap from="audio_info" to="$(arg audio_info_topic)" />
   </node>
 

--- a/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
+++ b/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
@@ -21,13 +21,13 @@ class DisplayBatteryGraphMode(I2CBase):
         # Assume battery topic is 1Hz
         self.display_bins = 10
         self.battery_percentages = [0] * self.display_duration
-        rospy.Subscriber("/atom_s3_mode", String,
+        rospy.Subscriber("atom_s3_mode", String,
                          callback=self.mode_cb, queue_size=1)
-        rospy.Subscriber("/battery/remaining_battery", Float32,
+        rospy.Subscriber("battery/remaining_battery", Float32,
                          callback=self.battery_cb, queue_size=1)
-        rospy.Subscriber("/battery/charge_status_string", String,
+        rospy.Subscriber("battery/charge_status_string", String,
                          callback=self.status_cb, queue_size=1)
-        rospy.Subscriber("/battery/battery_charge_current", Float32,
+        rospy.Subscriber("battery/battery_charge_current", Float32,
                          callback=self.current_cb, queue_size=1)
         rospy.Timer(rospy.Duration(1), self.timer_callback)
 

--- a/ros/riberry_startup/node_scripts/keyword_extraction.py
+++ b/ros/riberry_startup/node_scripts/keyword_extraction.py
@@ -32,7 +32,7 @@ class SpeechToKeyword:
             if any(self.contexts) is False:
                 rospy.logerr('Context data is empty or invalid')
                 return
-        rospy.Subscriber('/speech_to_text', SpeechRecognitionCandidates, self.speech_to_keyword_callback)
+        rospy.Subscriber('speech_to_text', SpeechRecognitionCandidates, self.speech_to_keyword_callback)
         self.keyword_pub = rospy.Publisher('~candidates', KeywordCandidates, queue_size=10)
 
     def speech_to_keyword_callback(self, msg):

--- a/ros/riberry_startup/node_scripts/pressure_control_mode.py
+++ b/ros/riberry_startup/node_scripts/pressure_control_mode.py
@@ -30,14 +30,14 @@ class PressureControlMode(I2CBase):
         # Button and mode callback
         self.mode = None
         rospy.Subscriber(
-            "/atom_s3_button_state", Int32, callback=self.button_cb, queue_size=1
+            "atom_s3_button_state", Int32, callback=self.button_cb, queue_size=1
         )
-        rospy.Subscriber("/atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
+        rospy.Subscriber("atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
 
         # Pressure control
         self.pressure_control_state = {}
         rospy.Subscriber(
-            "/fullbody_controller/pressure_control_interface/state",
+            "fullbody_controller/pressure_control_interface/state",
             PressureControl,
             callback=self.pressure_control_cb,
             queue_size=1,
@@ -49,7 +49,7 @@ class PressureControlMode(I2CBase):
         self.pressures = {}
         for idx in range(38, 66):
             rospy.Subscriber(
-                f"/fullbody_controller/pressure/{idx}",
+                f"fullbody_controller/pressure/{idx}",
                 Float32,
                 self.read_pressure,
                 callback_args=idx,

--- a/ros/riberry_startup/node_scripts/servo_control_mode.py
+++ b/ros/riberry_startup/node_scripts/servo_control_mode.py
@@ -28,14 +28,14 @@ class ServoControlMode(I2CBase):
         # Button and mode callback
         self.mode = None
         rospy.Subscriber(
-            "/atom_s3_button_state", Int32, callback=self.button_cb, queue_size=1
+            "atom_s3_button_state", Int32, callback=self.button_cb, queue_size=1
         )
-        rospy.Subscriber("/atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
+        rospy.Subscriber("atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
 
         # Servo on off
         self.servo_on_states = None
         rospy.Subscriber(
-            "/fullbody_controller/servo_on_off_real_interface/state",
+            "fullbody_controller/servo_on_off_real_interface/state",
             ServoOnOff,
             callback=self.servo_on_off_cb,
             queue_size=1,

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -109,19 +109,19 @@ class TeachingMode(I2CBase):
         # ROS callbacks
         self.mode = None
         rospy.Subscriber(
-            "/atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
+            "atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
         self.prev_state = State.WAIT
         self.state = State.WAIT
         self.additional_str = ""
         rospy.Subscriber(
-            "/atom_s3_button_state",
+            "atom_s3_button_state",
             Int32, callback=self.state_transition_cb, queue_size=1)
         rospy.Timer(rospy.Duration(0.1), self.update_atoms3)
 
         # Call action from rosservice
         rospy.Service('~play', SetBool, self.play_srv)
         self.virtual_button_pub = rospy.Publisher(
-            "/atom_s3_button_state", Int32, queue_size=1)
+            "atom_s3_button_state", Int32, queue_size=1)
 
         # Special actions
         self.special_actions = rospy.get_param(


### PR DESCRIPTION
Topic names beginning with “/” cannot change namespace.
To use node https://github.com/iory/riberry/pull/153, this PR removes the global namespace.

Some global namespaces remain, but I have removed the ones I have checked.