### PR TITLE
Display current ROS_MASTER_URI on pairing mode

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -380,9 +380,12 @@ class DisplayInformation:
                                 print("pairing failed")
                             else:
                                 pairing_info = new_pairing_info
-               # Double tap to reset ROS master
+                # Double tap to reset ROS master
                 if button_count == 2:
                     pairing_info = "localhost"
+                # Send string without header to display current ROS_MASTER_URI on monitor
+                ros_master_uri = os.environ['ROS_MASTER_URI']
+                self.com.write(ros_master_uri.replace("http://", "").replace(":11311", ""))
             else:
                 time.sleep(0.1)
 

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -74,7 +74,10 @@ void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
                 displayText += fancyMacAddress(mac.c_str()) + "\n";
             }
         }
-        displayText += "\n" + pairing.getStatus();
+        if (!lcd.color_str.isEmpty()) {
+            displayText += String("\n") + "MST" + lcd.color_str;
+        }
+        displayText += String("\n") + pairing.getStatus();
 
         if (!compareIgnoringEscapeSequences(prevStr, displayText)) {
             prevStr = displayText;


### PR DESCRIPTION
LCD is Like below:
```
1tap: ...
2tap: ...

My name:
...

Paired devices:
...

MST{Current display_information.py's ROS master IP} ## This line is added by this PR
```