### PR TITLE
Adjust the time to reach the initial position based on the current position 

### DIFF
--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -229,7 +229,11 @@ class MotionManager:
             speed = 1.0
         self.ri.servo_on()
         first_av = list(motion[0]['joint_states'].values())
-        self.ri.angle_vector(first_av, 3)
+        diff_av = first_av - self.ri.angle_vector()
+        max_diff_angle = max(map(abs, diff_av))
+        first_time = max_diff_angle / (np.pi/4)
+        print(f"Move to the initial position in {first_time} seconds")
+        self.ri.angle_vector(first_av, first_time)
         self.ri.wait_interpolation()
         # Play the actions from the second one onward
         prev_time = motion[0]['time']


### PR DESCRIPTION
This PR determines the time to move to the initial position from the current position at a speed of π/4 radians per second.

Example
- When the difference from the initial posture is large
-> 2.444250130342929 seconds
- When the difference from the initial posture is medium
-> 1.4400000173043535 seconds
- When the difference from the initial posture is small
-> 0.37950003313811936 seconds