### PR TITLE
Add arg to change speech_to_text topic name

### DIFF
--- a/ros/riberry_startup/launch/speech_to_action.launch
+++ b/ros/riberry_startup/launch/speech_to_action.launch
@@ -1,8 +1,11 @@
 <launch>
 
   <arg name="contexts_json" />
+  <arg name="speech_to_text_topic_name" default="speech_to_text"
+       doc="Change topic name when speech_to_text topic is published from different namespace computer." />
 
   <node pkg="riberry_startup" name="keyword_extraction" type="keyword_extraction.py">
+    <remap from="speech_to_text" to="$(arg speech_to_text_topic_name)" />
     <rosparam subst_value="true">
       contexts_json: $(arg contexts_json)
     </rosparam>

--- a/ros/riberry_startup/node_scripts/keyword_to_action.py
+++ b/ros/riberry_startup/node_scripts/keyword_to_action.py
@@ -23,7 +23,7 @@ class KeywordToAction:
 
         # Keyword extraction
         rospy.Subscriber(
-            "keyword_extraction", KeywordCandidates, self.keyword_cb)
+            "keyword_extraction/candidates", KeywordCandidates, self.keyword_cb)
         self.threshold = 0.65
 
         # Control robot
@@ -45,8 +45,7 @@ class KeywordToAction:
             rospy.loginfo(f"Get keyword: {highest_similarity_keyword}")
         else:
             rospy.logwarn(
-                "Unreliable keyword is detected:",
-                f"'{highest_similarity_keyword}'")
+                f"Unreliable keyword is detected: '{highest_similarity_keyword}'")
 
     def mode_cb(self, msg):
         self.mode = msg.data


### PR DESCRIPTION
When using Pairing Mode, the namespace for the speech_to_text topic changes.
This pull request allows you to modify the topic name.

However, please note that you must know your pairing partner's namespace beforehand.