### PR TITLE
Clear params for teaching_mode.py

### DIFF
--- a/ros/riberry_startup/launch/all_modes.launch
+++ b/ros/riberry_startup/launch/all_modes.launch
@@ -42,7 +42,7 @@
   <node name="teaching_mode"
         pkg="riberry_startup" type="teaching_mode.py"
         output="screen"
-        respawn="true">
+        respawn="true" clear_params="true">
   </node>
 
 </launch>


### PR DESCRIPTION
teaching_mode.py params such as `~special_actions` or `end_coords_name` should be reset.