### PR TITLE
Add system debug mode (e.g. memory usage)

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/system_debug_mode/system_debug_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/system_debug_mode/system_debug_mode.h
@@ -1,0 +1,67 @@
+#ifndef SYSTEM_DEBUG_MODE_H
+#define SYSTEM_DEBUG_MODE_H
+
+#include <mode.h>
+
+class SystemDebugMode : public Mode {
+public:
+    SystemDebugMode() : Mode("SystemDebugMode") {
+        previousFreeHeap = 0;  // Unknown at first time
+        totalFreeHeap = heap_caps_get_total_size(MALLOC_CAP_8BIT);
+    }
+
+private:
+    void task(PrimitiveLCD &lcd, CommunicationBase &com) override {
+        while (running) {
+#ifdef ATOM_S3
+            lcd.setTextSize(1.2);
+#endif
+            String str = "";
+            str += checkMemoryLeak();
+            if (prevStr.equals(str)) {
+                vTaskDelay(pdMS_TO_TICKS(10));
+            } else {
+                lcd.drawBlack();
+                lcd.printColorText(str);
+                prevStr = str;
+            }
+            vTaskDelay(pdMS_TO_TICKS(1000));
+        }
+    }
+
+    virtual void suspendTask() {
+        previousFreeHeap = currentFreeHeap;
+        Mode::suspendTask();
+    }
+
+    String checkMemoryLeak() {
+        String message = "";
+        char buf[120];
+
+        message += "Free heap [bytes]\n";
+        if (previousFreeHeap == 0) {  // First time
+            message += " Prev  Unknown\n";
+        } else {
+            sprintf(buf, " Prev  %d\n", previousFreeHeap);
+            message += String(buf);
+        }
+
+        currentFreeHeap = heap_caps_get_free_size(MALLOC_CAP_8BIT);
+        sprintf(buf, " Now   %d\n Total %d\n", currentFreeHeap, totalFreeHeap);
+        message += String(buf);
+
+        if (currentFreeHeap < previousFreeHeap) {
+            sprintf(buf, "\nMemory may leak. Lost %d bytes compared to previous run.\n",
+                    previousFreeHeap - currentFreeHeap);
+            message += String(buf);
+        }
+
+        return message;
+    }
+
+    size_t previousFreeHeap;
+    size_t currentFreeHeap;
+    size_t totalFreeHeap;
+};
+
+#endif  // SYSTEM_DEBUG_MODE_H

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -13,6 +13,7 @@
 #include <pressure_control_mode.h>
 #include <primitive_lcd.h>
 #include <servo_control_mode.h>
+#include <system_debug_mode.h>
 #include <teaching_mode.h>
 ButtonManager button_manager;
 PrimitiveLCD lcd;
@@ -53,11 +54,13 @@ DisplayOdomMode display_odom_mode;
 ServoControlMode servo_control_mode;
 PressureControlMode pressure_control_mode;
 TeachingMode teaching_mode;
+SystemDebugMode system_debug_mode;
 PairingMode pairing_mode(button_manager, pairing, comm);
 const std::vector<Mode *> allModes = {
         &display_information_mode,   &display_qrcode_mode, &display_image_mode,
         &display_battery_graph_mode, &display_odom_mode,   &servo_control_mode,
         &pressure_control_mode,      &teaching_mode,       &pairing_mode,
+        &system_debug_mode,
 };
 
 ModeManager modemanager(lcd, button_manager, comm, allModes);
@@ -86,6 +89,7 @@ void setup() {
     modemanager.addSelectedMode(display_information_mode);
     modemanager.addSelectedMode(display_qrcode_mode);
     modemanager.addSelectedMode(pairing_mode);
+    modemanager.addSelectedMode(system_debug_mode);
     modemanager.startCurrentMode();
 }
 

--- a/ros/riberry_startup/launch/all_modes.launch
+++ b/ros/riberry_startup/launch/all_modes.launch
@@ -18,6 +18,7 @@
       - ServoControlMode
       - PressureControlMode
       - TeachingMode
+      - SystemDebugMode
     </rosparam>
   </node>
 


### PR DESCRIPTION
When SystemDebugMode is executed, the difference from the previous execution is calculated


LCD message is like following:

```
Free heap [bytes]
 Prev  318755
 Now   285568
 Total 352716

Memory may leak. L
ost 33188 bytes co
mpared to previous
 run.
```