### PR TITLE
[AtomS3] Add comment for CPU usage in communication base task

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
@@ -260,6 +260,9 @@ void CommunicationBase::task(void* parameter) {
 
         while (true) {
             WireSlave.update();
+            // After increasing the delay time after WireSlave.update() from 1ms to 10ms, the CPU
+            // usage dropped from around 60% to 16%. If the CPU usage on Core 0 becomes too high, we
+            // should consider reducing this value accordingly.
             instance->delayWithTimeTracking(pdMS_TO_TICKS(1));
         }
 #if ARDUINO_USB_MODE


### PR DESCRIPTION
```
===== CPU Usage Monitor =====
Elapsed Time: 1000999 us

Core 0:
  CommunicationBase         : 16.86%
  ButtonManager             : 0.04%
  Mode Manager              : 0.01%
  Idle CPU Usage            : 83.09%

Core 1:
  Pairing                   : 0.00%
  DisplayInformationMode    : 0.00%
  DisplayQRcodeMode         : 0.00%
  PairingMode               : 0.00%
  SystemDebugMode           : 0.03%
  Idle CPU Usage            : 99.97%
```

After increasing the delay time in WireSlave.update from 1ms to 10ms, the CPU usage dropped from around 60% to 16%.
If the CPU usage on Core 0 becomes too high, we should consider reducing this value accordingly.