### PR TITLE
Display keyword detection error on LCD

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -401,8 +401,7 @@ class DisplayInformation:
                 ros_additional_message = None
             # Force mode change once according to ~atom_s3_force_mode topic
             if atom_s3_forced_mode is not None:
-                if atom_s3_forced_mode != atom_s3_mode:
-                    self.force_mode(atom_s3_forced_mode)
+                self.force_mode(atom_s3_forced_mode)
                 atom_s3_forced_mode = None
 
 

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -116,6 +116,9 @@ class TeachingMode(I2CBase):
         rospy.Subscriber(
             "atom_s3_button_state",
             Int32, callback=self.state_transition_cb, queue_size=1)
+        rospy.Subscriber(
+            "teaching_mode_additional_info",
+            String, callback=self.additional_info_cb, queue_size=1)
         rospy.Timer(rospy.Duration(0.1), self.update_atoms3)
 
         # Call action from rosservice
@@ -444,6 +447,9 @@ class TeachingMode(I2CBase):
             rospy.logerr(f"sent string: {sent_str}")
             rospy.logerr(f"The number of delimiter '{delimiter}' must be {delimiter_num}")
         self.write(sent_str)
+
+    def additional_info_cb(self, msg):
+        self.additional_str = msg.data
 
     def start_recording(self):
         """


### PR DESCRIPTION
If the keyword DETECTION is incomplete, display the following
- If the current mode is `TeachingMode`, move to `WAIT` state and display the error.
- If the current mode is not `TeachingMode`, move to `DisplayInformationMode` and display the error.