### PR TITLE
Register keyword and contexts by rosservice

### DIFF
--- a/ros/riberry_startup/CMakeLists.txt
+++ b/ros/riberry_startup/CMakeLists.txt
@@ -33,8 +33,14 @@ find_package(catkin REQUIRED COMPONENTS
 
 add_message_files(
   FILES
+  Context.msg
   ImuFace.msg
   KeywordCandidates.msg
+)
+
+add_service_files(
+  FILES
+  RegisterContexts.srv
 )
 
 generate_messages(

--- a/ros/riberry_startup/msg/Context.msg
+++ b/ros/riberry_startup/msg/Context.msg
@@ -1,0 +1,2 @@
+string keyword
+string[] context

--- a/ros/riberry_startup/srv/RegisterContexts.srv
+++ b/ros/riberry_startup/srv/RegisterContexts.srv
@@ -1,0 +1,4 @@
+riberry_startup/Context[] contexts
+---
+bool success
+string message


### PR DESCRIPTION
Test code to register keyword and contexts.

```
import rospy

from riberry_startup.msg import Context
from riberry_startup.srv import RegisterContexts
from riberry_startup.srv import RegisterContextsRequest


if __name__ == "__main__":
    rospy.init_node("register_keyword_test")

    req = RegisterContextsRequest(contexts=[])
    context = Context()
    context.keyword = "挨拶"
    context.context = ["おはよう", "こんにちは", "こんばんは"]
    req.contexts.append(context)
    context = Context()
    context.keyword = "感謝"
    context.context = ["ありがとう", "助かります"]
    req.contexts.append(context)

    rospy.wait_for_service('keyword_extraction/register_contexts')
    register_contexts= rospy.ServiceProxy(
        'keyword_extraction/register_contexts', RegisterContexts)
    register_contexts(req)
```