### PR TITLE
Use different serial instance in cpu_usage_monitor.h for AtomS3 and M5Stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project_dir: [firmware/atom_echo_i2c_audio,
-                      firmware/atom_s3_i2c_display,
-                      firmware/esp_now_pairing,
-                      ]
+        include:
+          - project_dir: firmware/atom_echo_i2c_audio
+            env_option: ""
+          - project_dir: firmware/atom_s3_i2c_display
+            env_option: ""
+          - project_dir: firmware/atom_s3_i2c_display
+            env_option: "-e m5stack-basic"
+          - project_dir: firmware/esp_now_pairing
+            env_option: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +41,7 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Build PlatformIO Project
-        run: pio run -d ${{ matrix.project_dir }}
+        run: pio run -d ${{ matrix.project_dir }} ${{ matrix.env_option }}
 
   typos:
     name: Typos

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -80,7 +80,12 @@ std::vector<ExecutionTimer *> executionTimers = {&pairing,
                                                  &teaching_mode,
                                                  &pairing_mode,
                                                  &system_debug_mode};
-CPUUsageMonitor cpu_usage_monitor(executionTimers);
+
+#ifdef ATOM_S3
+CPUUsageMonitor cpu_usage_monitor(executionTimers, &USBSerial);
+#elif USE_M5STACK_BASIC
+CPUUsageMonitor cpu_usage_monitor(executionTimers, &Serial);
+#endif
 
 void setup() {
 #ifdef ATOM_S3


### PR DESCRIPTION
Without this PR, `pio run -e m5stack-basic` fails.