### PR TITLE
Add channel parameter for esp now pairing

### DIFF
--- a/firmware/esp_now_pairing/lib/pairing/pairing.h
+++ b/firmware/esp_now_pairing/lib/pairing/pairing.h
@@ -17,7 +17,7 @@ struct PairingData {
 
 class Pairing : public ExecutionTimer {
 public:
-    Pairing();
+    Pairing(const int channel = 1);
 
     bool setupESPNOW();
     void waitForESPNOWSetup();
@@ -51,6 +51,8 @@ public:
 
 private:
     static MutexHelper mutex_;
+
+    static int _channel;
 
     // EspNow callbacks
     static void onDataSent(const uint8_t* mac_addr, esp_now_send_status_t status);


### PR DESCRIPTION
It is good to use ESP-NOW for data transfer in robots.
There is a library that allows using ESP-NOW in Python, and I have confirmed that communication works by setting it to channel 1.