### PR TITLE
ModeManager suspend task instead of delete task

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.cpp
+++ b/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.cpp
@@ -24,8 +24,8 @@ void ModeManager::task(void *parameter) {
     while (true) {
         // Check if selected Modes are changed
         if (!selectedModesStr.equals(instance->comm.selectedModesStr)) {
-            // Delete all modes
-            instance->deleteSelectedModes();
+            // Suspend all modes
+            instance->suspendSelectedModes();
             // Add selected modes
             selectedModesStr = instance->comm.selectedModesStr;
             char **selectedModesStrList = (char **)malloc(allModes->size() * sizeof(char *));
@@ -137,6 +137,14 @@ void ModeManager::deleteSelectedModes() {
     // Before deleting modes, all modes must be suspended
     for (int i = 0; i < selectedModes.size(); i++) {
         selectedModes[i]->deleteTask();
+    }
+    selectedModes.clear();
+}
+
+void ModeManager::suspendSelectedModes() {
+    // Before deleting modes, all modes must be suspended
+    for (int i = 0; i < selectedModes.size(); i++) {
+        selectedModes[i]->suspendTask();
     }
     selectedModes.clear();
 }

--- a/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.h
+++ b/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.h
@@ -36,6 +36,7 @@ private:
     void changeMode(int suspend_mode_index, int resume_mode_index);
     void stopCurrentMode();
     void deleteSelectedModes();
+    void suspendSelectedModes();
 };
 
 #endif


### PR DESCRIPTION
When I used `set_mode.py` with M5Stack, ModeManager was stucked.
With this PR, the problem seems to be disappeared.