### PR TITLE
Add Mode class which can use both I2C and UART communication

### DIFF
--- a/riberry/mode.py
+++ b/riberry/mode.py
@@ -1,0 +1,27 @@
+import rospy
+from std_msgs.msg import String
+
+from riberry.com.base import ComBase
+from riberry.com.i2c_base import I2CBase
+from riberry.com.uart_base import UARTBase
+
+
+class Mode:
+    def __init__(self):
+        device = ComBase.identify_device()
+        if device in ['m5stack-LLM', 'Linux', 'Darwin']:
+            self.com = UARTBase()
+        else:
+            self.com = I2CBase(0x42)
+
+        self.mode = None
+        rospy.Subscriber("atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
+
+    def write(self, data):
+        return self.com.write(data)
+
+    def read(self):
+        return self.com.read()
+
+    def mode_cb(self, msg):
+        self.mode = msg.data

--- a/ros/riberry_startup/launch/aerial_robot.launch
+++ b/ros/riberry_startup/launch/aerial_robot.launch
@@ -23,7 +23,6 @@
           respawn="true"
           output="screen">
       <param name="/i2c_device" value="$(arg i2c_device)" />
-      <remap from="/i2c_mode" to="/atom_s3_mode" />
     </node>
     <node name="display_odom_mode"
           pkg="riberry_startup" type="display_odom_mode.py"

--- a/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
+++ b/ros/riberry_startup/node_scripts/display_battery_graph_mode.py
@@ -5,24 +5,21 @@ from std_msgs.msg import String
 
 from riberry.battery import ChargeState
 from riberry.com.base import PacketType
-from riberry.com.i2c_base import I2CBase
+from riberry.mode import Mode
 
 
-class DisplayBatteryGraphMode(I2CBase):
-    def __init__(self, i2c_addr):
-        super().__init__(i2c_addr)
+class DisplayBatteryGraphMode(Mode):
+    def __init__(self):
+        super().__init__()
 
         self.charge_str_to_num = {str(state): state.value
                                     for state in ChargeState}
-        self.mode = None
         self.charge_status = None
         self.charge_current = 0
         self.display_duration = rospy.get_param("~display_duration", 3600)
         # Assume battery topic is 1Hz
         self.display_bins = 10
         self.battery_percentages = [0] * self.display_duration
-        rospy.Subscriber("atom_s3_mode", String,
-                         callback=self.mode_cb, queue_size=1)
         rospy.Subscriber("battery/remaining_battery", Float32,
                          callback=self.battery_cb, queue_size=1)
         rospy.Subscriber("battery/charge_status_string", String,
@@ -36,7 +33,7 @@ class DisplayBatteryGraphMode(I2CBase):
         Check AtomS3 mode.
         """
         previous_mode = self.mode
-        self.mode = msg.data
+        super().mode_cb(msg)
         if self.mode == "DisplayBatteryGraphMode":
             if previous_mode != self.mode:
                 rospy.loginfo('start display battery graph mode')
@@ -76,5 +73,5 @@ class DisplayBatteryGraphMode(I2CBase):
 
 if __name__ == "__main__":
     rospy.init_node("display_battery_graph_mode")
-    dbgm = DisplayBatteryGraphMode(0x42)
+    dbgm = DisplayBatteryGraphMode()
     rospy.spin()

--- a/ros/riberry_startup/node_scripts/display_odom_mode.py
+++ b/ros/riberry_startup/node_scripts/display_odom_mode.py
@@ -6,23 +6,20 @@ from colorama import Fore
 from nav_msgs.msg import Odometry
 import rospy
 from std_msgs.msg import Float32
-from std_msgs.msg import String
 
 from riberry.com.base import PacketType
-from riberry.com.i2c_base import I2CBase
+from riberry.mode import Mode
 from riberry.network import get_ip_address
 from riberry.network import get_ros_master_ip
 
 
-class DisplayOdomMode(I2CBase):
-    def __init__(self, i2c_addr):
-        super().__init__(i2c_addr)
+class DisplayOdomMode(Mode):
+    def __init__(self):
+        super().__init__()
 
-        self.mode = None
         self.min_battery_voltage = rospy.get_param("~min_battery_voltage", 14.0)
         self.max_battery_voltage = rospy.get_param("~max_battery_voltage", 16.0)
         self.battery_pub = rospy.Publisher("~remaining_battery", Float32, queue_size=1)
-        rospy.Subscriber("/i2c_mode", String, callback=self.mode_cb, queue_size=1)
         rospy.Subscriber(
             "uav/cog/odom", Odometry, callback=self.odometory_cb, queue_size=1
         )
@@ -40,9 +37,6 @@ class DisplayOdomMode(I2CBase):
 
     def odometory_cb(self, msg):
         self.odom = msg
-
-    def mode_cb(self, msg):
-        self.mode = msg.data
 
     def timer_callback(self, event):
         if self.mode == "DisplayInformationMode":
@@ -86,5 +80,5 @@ class DisplayOdomMode(I2CBase):
 
 if __name__ == "__main__":
     rospy.init_node("display_battery_mode")
-    scm = DisplayOdomMode(0x42)
+    scm = DisplayOdomMode()
     rospy.spin()

--- a/ros/riberry_startup/node_scripts/pressure_control_mode.py
+++ b/ros/riberry_startup/node_scripts/pressure_control_mode.py
@@ -7,16 +7,15 @@ from skrobot.model import RobotModel
 from skrobot.utils.urdf import no_mesh_load_mode
 from std_msgs.msg import Float32
 from std_msgs.msg import Int32
-from std_msgs.msg import String
 
 from riberry.com.base import PacketType
-from riberry.com.i2c_base import I2CBase
+from riberry.mode import Mode
 from riberry.select_list import SelectList
 
 
-class PressureControlMode(I2CBase):
-    def __init__(self, i2c_addr):
-        super().__init__(i2c_addr)
+class PressureControlMode(Mode):
+    def __init__(self):
+        super().__init__()
         # Create robot model to control pressure
         robot_model = RobotModel()
         namespace = ""
@@ -28,11 +27,9 @@ class PressureControlMode(I2CBase):
         )
 
         # Button and mode callback
-        self.mode = None
         rospy.Subscriber(
             "atom_s3_button_state", Int32, callback=self.button_cb, queue_size=1
         )
-        rospy.Subscriber("atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
 
         # Pressure control
         self.pressure_control_state = {}
@@ -76,12 +73,6 @@ class PressureControlMode(I2CBase):
             )
             self.toggle_pressure_control(idx)
             self.send_string()
-
-    def mode_cb(self, msg):
-        """
-        Check AtomS3 mode.
-        """
-        self.mode = msg.data
 
     def pressure_control_cb(self, msg):
         self.pressure_control_state[f"{msg.board_idx}"] = msg
@@ -151,5 +142,5 @@ class PressureControlMode(I2CBase):
 
 if __name__ == "__main__":
     rospy.init_node("pressure_control_mode")
-    pcm = PressureControlMode(0x42)
+    pcm = PressureControlMode()
     rospy.spin()

--- a/ros/riberry_startup/node_scripts/servo_control_mode.py
+++ b/ros/riberry_startup/node_scripts/servo_control_mode.py
@@ -6,15 +6,14 @@ import rospy
 from skrobot.model import RobotModel
 from skrobot.utils.urdf import no_mesh_load_mode
 from std_msgs.msg import Int32
-from std_msgs.msg import String
 
 from riberry.com.base import PacketType
-from riberry.com.i2c_base import I2CBase
+from riberry.mode import Mode
 
 
-class ServoControlMode(I2CBase):
-    def __init__(self, i2c_addr):
-        super().__init__(i2c_addr)
+class ServoControlMode(Mode):
+    def __init__(self):
+        super().__init__()
         # Create robot model to control servo
         robot_model = RobotModel()
         namespace = ""
@@ -26,11 +25,9 @@ class ServoControlMode(I2CBase):
         )
 
         # Button and mode callback
-        self.mode = None
         rospy.Subscriber(
             "atom_s3_button_state", Int32, callback=self.button_cb, queue_size=1
         )
-        rospy.Subscriber("atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
 
         # Servo on off
         self.servo_on_states = None
@@ -54,12 +51,6 @@ class ServoControlMode(I2CBase):
                 + " Toggle servo control."
             )
             self.toggle_servo_on_off()
-
-    def mode_cb(self, msg):
-        """
-        Check AtomS3 mode.
-        """
-        self.mode = msg.data
 
     def servo_on_off_cb(self, msg):
         self.servo_on_states = msg
@@ -91,5 +82,5 @@ class ServoControlMode(I2CBase):
 
 if __name__ == "__main__":
     rospy.init_node("servo_control_mode")
-    scm = ServoControlMode(0x42)
+    scm = ServoControlMode()
     rospy.spin()

--- a/ros/riberry_startup/node_scripts/set_mode.py
+++ b/ros/riberry_startup/node_scripts/set_mode.py
@@ -3,12 +3,12 @@
 import rospy
 
 from riberry.com.base import PacketType
-from riberry.com.i2c_base import I2CBase
+from riberry.mode import Mode
 
 
-class SetMode(I2CBase):
-    def __init__(self, i2c_addr):
-        super().__init__(i2c_addr)
+class SetMode(Mode):
+    def __init__(self):
+        super().__init__()
         self.mode_names = self.get_mode_names_from_rosparam()
         rospy.Timer(rospy.Duration(1), self.timer_callback)
 
@@ -29,5 +29,5 @@ class SetMode(I2CBase):
 
 if __name__ == "__main__":
     rospy.init_node("set_mode")
-    SetMode(0x42)
+    SetMode()
     rospy.spin()

--- a/ros/riberry_startup/node_scripts/teaching_mode.py
+++ b/ros/riberry_startup/node_scripts/teaching_mode.py
@@ -14,8 +14,8 @@ from std_srvs.srv import SetBool
 from std_srvs.srv import SetBoolResponse
 
 from riberry.com.base import PacketType
-from riberry.com.i2c_base import I2CBase
 from riberry.filecheck_utils import get_cache_dir
+from riberry.mode import Mode
 from riberry.select_list import SelectList
 from riberry.teaching_manager import TeachingManager
 
@@ -74,7 +74,7 @@ class State(Enum):
     CHANGE_MOTION_NAME = 6
 
 
-class TeachingMode(I2CBase):
+class TeachingMode(Mode):
     """
     TeachingMode is a class that manages robot motion teaching and playback through AtomS3 communication.
 
@@ -97,8 +97,8 @@ class TeachingMode(I2CBase):
         additional_str (str): Additional message string for display during operations.
     """
 
-    def __init__(self, i2c_addr):
-        super().__init__(i2c_addr)
+    def __init__(self):
+        super().__init__()
         self.teaching_manager = TeachingManager()
         self.playing = False
         self.new_motion_name = None
@@ -106,9 +106,6 @@ class TeachingMode(I2CBase):
         self.load_play_list()
 
         # ROS callbacks
-        self.mode = None
-        rospy.Subscriber(
-            "atom_s3_mode", String, callback=self.mode_cb, queue_size=1)
         self.prev_state = State.WAIT
         self.state = State.WAIT
         self.additional_str = ""
@@ -153,7 +150,7 @@ class TeachingMode(I2CBase):
         """
         if self.mode != "TeachingMode" and msg.data == "TeachingMode":
             rospy.loginfo("Start teaching mode")
-        self.mode = msg.data
+        super().mode_cb(msg)
 
     def state_transition_cb(self, msg):
         """Handles button state transitions for recording and playback.
@@ -573,5 +570,5 @@ class TeachingMode(I2CBase):
 if __name__ == '__main__':
     # Main
     rospy.init_node('teaching_mode', anonymous=True)
-    TeachingMode(0x42)
+    TeachingMode()
     rospy.spin()


### PR DESCRIPTION
This PR creates `Mode` class in mode.py. This class can use both I2C and UART communication.
Now each XX_mode.py inherits this `Mode` class.