### PR TITLE
Use ModeType for mode identification

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_battery_graph_mode/display_battery_graph_mode.cpp
@@ -1,6 +1,6 @@
 #include <display_battery_graph_mode.h>
 
-DisplayBatteryGraphMode::DisplayBatteryGraphMode() : Mode("DisplayBatteryGraphMode") {}
+DisplayBatteryGraphMode::DisplayBatteryGraphMode() : Mode(ModeType::DISPLAY_BATTERY_GRAPH) {}
 
 void DisplayBatteryGraphMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     graph_h = (lcd.height() - title_h - x_label_h - 2);

--- a/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_image_mode/display_image_mode.cpp
@@ -1,6 +1,6 @@
 #include <display_image_mode.h>
 
-DisplayImageMode::DisplayImageMode() : Mode("DisplayImageMode") {}
+DisplayImageMode::DisplayImageMode() : Mode(ModeType::DISPLAY_IMAGE) {}
 
 void DisplayImageMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     while (running) {

--- a/firmware/atom_s3_i2c_display/lib/display_qrcode_mode/display_qrcode_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/display_qrcode_mode/display_qrcode_mode.cpp
@@ -1,6 +1,6 @@
 #include <display_qrcode_mode.h>
 
-DisplayQRcodeMode::DisplayQRcodeMode() : Mode("DisplayQRcodeMode") {}
+DisplayQRcodeMode::DisplayQRcodeMode() : Mode(ModeType::DISPLAY_QRCODE) {}
 
 void DisplayQRcodeMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     while (running) {

--- a/firmware/atom_s3_i2c_display/lib/mode/mode.h
+++ b/firmware/atom_s3_i2c_display/lib/mode/mode.h
@@ -5,6 +5,7 @@
 #include <communication_base.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <mode_type.h>
 #include <primitive_lcd.h>
 #include <string_utils.h>
 
@@ -12,7 +13,7 @@
 
 class Mode : public ExecutionTimer {
 public:
-    Mode(const String& name) : ExecutionTimer(name), running(false) {}
+    Mode(const ModeType::Name& name) : ExecutionTimer(ModeType::toString(name)), running(false) {}
 
     virtual void suspendTask() {
         if (taskHandle != NULL) {

--- a/firmware/atom_s3_i2c_display/lib/mode/mode_type.h
+++ b/firmware/atom_s3_i2c_display/lib/mode/mode_type.h
@@ -1,0 +1,52 @@
+#ifndef MODE_TYPE_H
+#define MODE_TYPE_H
+
+namespace ModeType {
+enum Name : uint8_t {
+    NONE = 0x00,
+    DISPLAY_INFORMATION = 0x01,
+    DISPLAY_QRCODE = 0x02,
+    DISPLAY_IMAGE = 0x03,
+    DISPLAY_BATTERY_GRAPH = 0x04,
+    DISPLAY_ODOM = 0x05,
+    SERVO_CONTROL = 0x06,
+    PRESSURE_CONTROL = 0x07,
+    TEACHING = 0x08,
+    SPEECH_TO_TEXT = 0x09,
+    SYSTEM_DEBUG = 0x10,
+    PAIRING = 0x11,
+};
+
+inline String toString(Name name) {
+    switch (name) {
+        case NONE:
+            return "None";
+        case DISPLAY_INFORMATION:
+            return "DisplayInformationMode";
+        case DISPLAY_QRCODE:
+            return "DisplayQRcodeMode";
+        case DISPLAY_IMAGE:
+            return "DisplayImageMode";
+        case DISPLAY_BATTERY_GRAPH:
+            return "DisplayBatteryGraphMode";
+        case DISPLAY_ODOM:
+            return "DisplayOdomMode";
+        case SERVO_CONTROL:
+            return "ServoControlMode";
+        case PRESSURE_CONTROL:
+            return "PressureControlMode";
+        case TEACHING:
+            return "TeachingMode";
+        case SPEECH_TO_TEXT:
+            return "SpeechToTextMode";
+        case SYSTEM_DEBUG:
+            return "SystemDebugMode";
+        case PAIRING:
+            return "PairingMode";
+        default:
+            return "Unknown";
+    }
+}
+}  // namespace ModeType
+
+#endif  // MODE_TYPE_H

--- a/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/pairing_mode/pairing_mode.cpp
@@ -4,7 +4,7 @@
 #include <string_utils.h>
 
 PairingMode::PairingMode(ButtonManager &button_manager, Pairing &pairing, CommunicationBase &com)
-    : Mode("PairingMode"), button_manager(button_manager), pairing(pairing), com(com) {}
+    : Mode(ModeType::PAIRING), button_manager(button_manager), pairing(pairing), com(com) {}
 
 void PairingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     prevStr = "";

--- a/firmware/atom_s3_i2c_display/lib/system_debug_mode/system_debug_mode.h
+++ b/firmware/atom_s3_i2c_display/lib/system_debug_mode/system_debug_mode.h
@@ -6,7 +6,7 @@
 
 class SystemDebugMode : public Mode {
 public:
-    SystemDebugMode() : Mode("SystemDebugMode") {
+    SystemDebugMode() : Mode(ModeType::SYSTEM_DEBUG) {
         previousFreeHeap = 0;  // Unknown at first time
         totalFreeHeap = heap_caps_get_total_size(MALLOC_CAP_8BIT);
     }

--- a/firmware/atom_s3_i2c_display/lib/teaching_mode/teaching_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/teaching_mode/teaching_mode.cpp
@@ -1,6 +1,6 @@
 #include <teaching_mode.h>
 
-TeachingMode::TeachingMode() : Mode("TeachingMode") {}
+TeachingMode::TeachingMode() : Mode(ModeType::TEACHING) {}
 
 void TeachingMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
     while (running) {

--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -44,15 +44,15 @@ CommunicationBase comm(lcd, button_manager, pairing, &Serial);
 #endif
 
 // Define all available modes
-Mode display_information_mode("DisplayInformationMode");
+Mode display_information_mode(ModeType::DISPLAY_INFORMATION);
 DisplayQRcodeMode display_qrcode_mode;
 DisplayImageMode display_image_mode;
 DisplayBatteryGraphMode display_battery_graph_mode;
-Mode display_odom_mode("DisplayOdomMode");
-Mode servo_control_mode("ServoControlMode");
-Mode pressure_control_mode("PressureControlMode");
+Mode display_odom_mode(ModeType::DISPLAY_ODOM);
+Mode servo_control_mode(ModeType::SERVO_CONTROL);
+Mode pressure_control_mode(ModeType::PRESSURE_CONTROL);
 TeachingMode teaching_mode;
-Mode speech_to_text_mode("SpeechToTextMode");
+Mode speech_to_text_mode(ModeType::SPEECH_TO_TEXT);
 SystemDebugMode system_debug_mode;
 PairingMode pairing_mode(button_manager, pairing, comm);
 const std::vector<Mode *> allModes = {


### PR DESCRIPTION
Sending mode name via I2C is redundant in byte length.
This PR add ModeType Enum to each mode.