### PR TITLE
Use byte list instead of string for select mode

### DIFF
--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.cpp
@@ -4,7 +4,7 @@ CommunicationBase* CommunicationBase::instance = nullptr;
 Stream* CommunicationBase::_stream = nullptr;
 uint8_t CommunicationBase::requestBytes[100];
 String CommunicationBase::forcedMode = "";
-String CommunicationBase::selectedModesStr = "";
+uint8_t CommunicationBase::selectedModesBytes[100];
 Role CommunicationBase::role;
 bool CommunicationBase::pairingEnabled = false;
 
@@ -263,7 +263,10 @@ void CommunicationBase::handleForceModePacket(const String& str, int offset) {
 
 void CommunicationBase::handleSelectedModePacket(const String& str, int offset) {
     if (str.length() > offset) {
-        selectedModesStr = str.substring(offset);
+        String substring = str.substring(offset);
+        const uint8_t* buff = (const uint8_t*)substring.c_str();
+        size_t byteLen = buff[0];
+        memcpy(selectedModesBytes, buff, byteLen);
     }
 }
 

--- a/firmware/atom_s3_i2c_display/lib/com/communication_base.h
+++ b/firmware/atom_s3_i2c_display/lib/com/communication_base.h
@@ -31,7 +31,7 @@ public:
     static void setRequestBytes(uint8_t* bytes, size_t byteLen);
 
     static String forcedMode;
-    static String selectedModesStr;
+    static uint8_t selectedModesBytes[100];
     static Role role;
     void startPairing() { pairingEnabled = true; }
     void stopPairing() { pairingEnabled = false; }

--- a/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.h
+++ b/firmware/atom_s3_i2c_display/lib/mode_manager/mode_manager.h
@@ -28,7 +28,7 @@ private:
 
     static const std::vector<Mode *> *allModes;
     static std::vector<Mode *> selectedModes;
-    static String selectedModesStr;
+    static uint8_t selectedModesBytes[100];
     static int current_mode_index;
 
     static void task(void *parameter);

--- a/ros/riberry_startup/node_scripts/set_mode.py
+++ b/ros/riberry_startup/node_scripts/set_mode.py
@@ -5,6 +5,7 @@ from std_msgs.msg import String
 
 from riberry.com.base import PacketType
 from riberry.mode import Mode
+from riberry.mode_type import string_to_mode_type
 
 
 class SetMode(Mode):
@@ -29,8 +30,11 @@ class SetMode(Mode):
     def send_selected_modes(self):
         rospy.loginfo(f"Change selected mode: {self.mode_names}")
         header = [PacketType.SELECTED_MODE]
-        selected_modes = list(map(ord, self.mode_names))
-        self.write(header + selected_modes)
+        mode_byte_list = [
+            string_to_mode_type(mode_name).value for mode_name in self.mode_names.split(",")]
+        msg_size = len(mode_byte_list) + 1
+        packet = header + [msg_size] + mode_byte_list
+        self.write(packet)
         rospy.sleep(3)  # Wait until selected mode is applied
 
 


### PR DESCRIPTION
For select mode,
- previously, string like `DisplayInformaitonMode,DisplayQRcodeMode,PairingMode` is used.
- now, byte list like `4 1 2 17` is used.

The byte list consists of the following:

```
0 byte: header packet
1 byte: Remaining byte length
2 byte and after: mode type
```

This PR save packet length.