### PR TITLE
read() must return bytes in uart_base.py

### DIFF
--- a/riberry/com/uart_base.py
+++ b/riberry/com/uart_base.py
@@ -119,12 +119,13 @@ class UARTBase(ComBase):
             except Timeout as e:
                 print(e)
 
+    # read() must return bytes, not None
     def read(self):
         try:
             if self.serial is None:
                 print("[uart_base] Serial is not initialized. Try to connect serial.")
                 self._connect_serial()
-                return
+                return b''
             if self.serial.in_waiting:
                 return self.serial.read(self.serial.in_waiting or 1)
             else:
@@ -135,3 +136,4 @@ class UARTBase(ComBase):
                 self._connect_serial()
             except serial.serialutil.SerialException:
                 print("[uart_base] Serial reconnection failed.")
+            return b''


### PR DESCRIPTION
Previously, `object of type 'NoneType' has no len()` error sometimes occurs at the following code.
https://github.com/iory/riberry/blob/7090b39d5da2d6eff2f7c07dba39f773b0176437/bin/display_information.py#L344-L345

With this PR, read() must returns bytes.