### PR TITLE
Add delay between adding modes

### DIFF
--- a/firmware/atom_s3_i2c_display/src/main.cpp
+++ b/firmware/atom_s3_i2c_display/src/main.cpp
@@ -55,7 +55,7 @@ TeachingMode teaching_mode;
 Mode speech_to_text_mode(ModeType::SPEECH_TO_TEXT);
 SystemDebugMode system_debug_mode;
 PairingMode pairing_mode(button_manager, pairing, comm);
-const std::vector<Mode *> allModes = {
+const std::vector<Mode*> allModes = {
         &display_information_mode,   &display_qrcode_mode, &display_image_mode,
         &display_battery_graph_mode, &display_odom_mode,   &servo_control_mode,
         &pressure_control_mode,      &teaching_mode,       &pairing_mode,
@@ -63,21 +63,21 @@ const std::vector<Mode *> allModes = {
 };
 
 ModeManager modemanager(lcd, button_manager, comm, allModes);
-std::vector<ExecutionTimer *> executionTimers = {&pairing,
-                                                 &comm,
-                                                 &button_manager,
-                                                 &modemanager,
-                                                 &display_information_mode,
-                                                 &display_qrcode_mode,
-                                                 &display_image_mode,
-                                                 &display_battery_graph_mode,
-                                                 &display_odom_mode,
-                                                 &servo_control_mode,
-                                                 &pressure_control_mode,
-                                                 &teaching_mode,
-                                                 &pairing_mode,
-                                                 &system_debug_mode,
-                                                 &speech_to_text_mode};
+std::vector<ExecutionTimer*> executionTimers = {&pairing,
+                                                &comm,
+                                                &button_manager,
+                                                &modemanager,
+                                                &display_information_mode,
+                                                &display_qrcode_mode,
+                                                &display_image_mode,
+                                                &display_battery_graph_mode,
+                                                &display_odom_mode,
+                                                &servo_control_mode,
+                                                &pressure_control_mode,
+                                                &teaching_mode,
+                                                &pairing_mode,
+                                                &system_debug_mode,
+                                                &speech_to_text_mode};
 
 #ifdef ATOM_S3
 CPUUsageMonitor cpu_usage_monitor(executionTimers, &USBSerial);
@@ -111,11 +111,13 @@ void setup() {
     button_manager.createTask(0);
     comm.createTask(0);
     modemanager.createTask(0);
-    // By default, DisplayInformationMode, DisplayQRcodeMode and PairingMode are added
-    modemanager.addSelectedMode(display_information_mode);
-    modemanager.addSelectedMode(display_qrcode_mode);
-    modemanager.addSelectedMode(pairing_mode);
-    modemanager.addSelectedMode(system_debug_mode);
+    Mode* defaultModes[] = {&display_information_mode, &display_qrcode_mode, &pairing_mode,
+                            &system_debug_mode};
+    for (Mode* mode : defaultModes) {
+        modemanager.addSelectedMode(*mode);
+        // AtomS3 I2C version causes heap error when modes are added without delay
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
     modemanager.startCurrentMode();
 }
 


### PR DESCRIPTION
I don't know the reason, but the following delay is important for AtomS3 I2C version.

```
    for (Mode* mode : defaultModes) {
        modemanager.addSelectedMode(*mode);
        // AtomS3 I2C version causes heap error when modes are added without delay
        vTaskDelay(pdMS_TO_TICKS(1));
    }
    ```