### PR TITLE
Using socket communication for wifi-connect and display_information

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -463,6 +463,7 @@ class DisplayInformation:
                         send_wifi_connect_command("restart_wifi_connect")
                         time.sleep(2.0)
                 else:
+                    print('Display WifiSettings information')
                     if wifi_status == 'running':
                         self.display_qrcode(f"WIFI:S:{ssid};T:nopass;;")
                     else:

--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -31,7 +31,8 @@ from riberry.network import get_mac_address
 from riberry.network import get_ros_master_ip
 from riberry.network import get_wifi_info
 from riberry.network import wait_and_get_ros_ip
-from riberry.wifi_connect_utils import send_wifi_control_command
+from riberry.wifi_connect_utils import get_wifi_connect_status
+from riberry.wifi_connect_utils import send_wifi_connect_command
 
 # Ensure that the standard output is line-buffered. This makes sure that
 # each line of output is flushed immediately, which is useful for logging.
@@ -467,8 +468,13 @@ class DisplayInformation:
                 time.sleep(0.1)
                 wifi_request = self.com.read()
                 if wifi_request[1:] == b'wifi_connect':
-                    print("Starting wifi_connect")
-                    send_wifi_control_command("restart_wifi_connect")
+                    status = get_wifi_connect_status()
+                    if status == 'running':
+                        print("Stop wifi_connect")
+                        send_wifi_connect_command("stop_wifi_connect")
+                    elif status == 'stopped':
+                        print("Starting wifi_connect")
+                        send_wifi_connect_command("restart_wifi_connect")
                 else:
                     self.display_wifi_settings()
             else:

--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -400,6 +400,10 @@ class DisplayInformation:
                         except Exception as e:
                             print(f"Firmware update failed: {e}")
             run_button_count = button_count
+            wifi_status = get_wifi_connect_status()
+            if wifi_status == 'running' and mode != 'WiFiSettingsMode':
+                self.force_mode("WiFiSettingsMode")
+                print("Mode has been forcibly changed to WiFiSettingsMode")
             print(f"Mode: {mode} device_type: {self.com.device_type}")
             # Display data according to mode
             if mode == "DisplayInformationMode":
@@ -449,22 +453,20 @@ class DisplayInformation:
                 self.com.write([PacketType.GET_ADDITIONAL_REQUEST])
                 time.sleep(0.1)
                 wifi_request = self.com.read()
-                status = get_wifi_connect_status()
                 if wifi_request[1:] == b'wifi_connect':
-                    if status == 'running':
+                    if wifi_status == 'running':
                         print("Stop wifi_connect")
                         send_wifi_connect_command("stop_wifi_connect")
                         time.sleep(2.0)
-                    elif status == 'stopped':
+                    elif wifi_status == 'stopped':
                         print("Starting wifi_connect")
                         send_wifi_connect_command("restart_wifi_connect")
                         time.sleep(2.0)
                 else:
-                    if status == 'running':
+                    if wifi_status == 'running':
                         self.display_qrcode(f"WIFI:S:{ssid};T:nopass;;")
                     else:
                         self.display_wifi_settings()
-                del status
             else:
                 time.sleep(0.1)
             if mode != "DisplayInformationMode":

--- a/firmware/atom_s3_i2c_display/lib/wifi_settings_mode/wifi_settings_mode.cpp
+++ b/firmware/atom_s3_i2c_display/lib/wifi_settings_mode/wifi_settings_mode.cpp
@@ -6,7 +6,6 @@ WiFiSettingsMode::WiFiSettingsMode(ButtonManager &button_manager)
     : Mode(ModeType::WIFI_SETTINGS), button_manager(button_manager) {}
 
 void WiFiSettingsMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
-    String prevQrCodeData = "";
     prevStr = "";
     unsigned long prevTime = millis();
     ButtonState buttonState;
@@ -21,23 +20,23 @@ void WiFiSettingsMode::task(PrimitiveLCD &lcd, CommunicationBase &com) {
         buttonState = button_manager.getButtonState();
         if (previousButtonState != buttonState) {
             previousButtonState = buttonState;
-            if (buttonState == DOUBLE_CLICK) {
+            if (buttonState == SINGLE_CLICK) {
                 com.setAdditionalRequestBytes((uint8_t *)"wifi_connect", 12);
                 prevTime = millis();
+                prevStr = "";
             }
         }
-        if (!lcd.qrCodeData.isEmpty()) {
-            if (!compareIgnoringEscapeSequences(prevQrCodeData, lcd.qrCodeData)) {
-                lcd.drawBlack();
-                lcd.drawQRcode(lcd.qrCodeData);
-            }
-            prevQrCodeData = lcd.qrCodeData;
-        } else {
-            if (!compareIgnoringEscapeSequences(prevStr, lcd.color_str)) {
-                lcd.drawBlack();
-                prevStr = lcd.color_str;
-                lcd.printColorText(lcd.color_str);
-            }
+        if (!lcd.color_str.isEmpty() && !compareIgnoringEscapeSequences(prevStr, lcd.color_str)) {
+            lcd.drawBlack();
+            prevStr = lcd.color_str;
+            lcd.printColorText(lcd.color_str);
+            lcd.color_str = "";
+        } else if (!lcd.qrCodeData.isEmpty() &&
+                   !compareIgnoringEscapeSequences(prevStr, lcd.qrCodeData)) {
+            lcd.drawBlack();
+            prevStr = lcd.qrCodeData;
+            lcd.drawQRcode(lcd.qrCodeData);
+            lcd.qrCodeData = "";
         }
         delayWithTimeTracking(pdMS_TO_TICKS(100));
     }

--- a/riberry/wifi_connect_utils.py
+++ b/riberry/wifi_connect_utils.py
@@ -1,8 +1,22 @@
 import socket
 
 
-def send_wifi_control_command(command, socket_path='\0wifi_connect'):
+def send_wifi_connect_command(command, socket_path='\0wifi_connect'):
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.connect(socket_path)
     client.send(command.encode())
     client.close()
+
+def get_wifi_connect_status(socket_path='\0wifi_connect'):
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+    try:
+        client.connect(socket_path)
+        client.send(b"status")
+        response = client.recv(1024).decode().strip()
+        print(f"wifi-connect status: {response}")
+        return response
+    except Exception as e:
+        print(f"Error communicating with server: {e}")
+    finally:
+        client.close()

--- a/riberry/wifi_connect_utils.py
+++ b/riberry/wifi_connect_utils.py
@@ -1,0 +1,8 @@
+import socket
+
+
+def send_wifi_control_command(command, socket_path='\0wifi_connect'):
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.connect(socket_path)
+    client.send(command.encode())
+    client.close()

--- a/ros/riberry_startup/launch/all_modes.launch
+++ b/ros/riberry_startup/launch/all_modes.launch
@@ -20,6 +20,7 @@
       - TeachingMode
       - SystemDebugMode
       - FirmwareUpdateMode <!-- Enabled by display_information.service -->
+      - WiFiSettingsMode <!-- Enabled by display_information.service -->
     </rosparam>
   </node>
 


### PR DESCRIPTION
This PR enables communication between `wifi-connect` and `display_information` via socket communication.

Previously, `display_information` had to forcibly terminate wifi-connect using pkill, but this is no longer necessary.

Additionally, the Atom S3 can now toggle wifi-connect on and off with a `single click`.