### PR TITLE
Support Radxa zero3

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ If you are concerned about the security of the network:
 # sudo rm -f /etc/NetworkManager/system-connections/*
 ```
 
+## Install wifi-connect
+
+```
+sudo apt install -y curl unzip
+curl https://gist.githubusercontent.com/708yamaguchi/5dc14b90fedc30ca6785f8f7fb741627/raw/71de8351897517721c23bc6fe12f974ed6582a3a/radxa-install.sh | bash
+```
+
 ## Contributing
 
 ### Automatic Formatting

--- a/bin/start-wifi-connect.py
+++ b/bin/start-wifi-connect.py
@@ -177,7 +177,7 @@ def start_wifi_connect(model, mac_address):
         return
     try:
         wifi_connect_process = subprocess.Popen(
-            ["wifi-connect", "-s", f"{model}-{mac_address}", "-g", "192.168.4.1", "-d", "192.168.4.2,192.168.4.5"]
+            ["/usr/local/sbin/wifi-connect", "-s", f"{model}-{mac_address}", "-g", "192.168.4.1", "-d", "192.168.4.2,192.168.4.5"]
         )
         print("WiFi Connect started successfully.")
     except Exception as e:

--- a/install.py
+++ b/install.py
@@ -105,6 +105,14 @@ def execute_dtc_command(dry_run, output_path, source_dts):
         )
 
 
+def ros_exists():
+    ros_types = ['one', 'noetic']
+    for ros_type in ros_types:
+        if osp.isfile(f"/opt/ros/{ros_type}/setup.bash"):
+            return True
+    return False
+
+
 def main(dry_run=False, enable_oneshot=False):
     if dry_run is False and os.geteuid() != 0:
         print("This script must be run as root.")
@@ -129,9 +137,15 @@ def main(dry_run=False, enable_oneshot=False):
     create_symlinks("./etc/opt/riberry", "/etc/opt/riberry", dry_run=dry_run)
 
     added_user_symlinks = []
-    added_symlinks = create_symlinks(
-        "./ros/riberry_startup/systemd", systemd_target_dir, dry_run=dry_run
-    )
+    added_symlinks = []
+    if ros_exists():
+        added_symlinks += create_symlinks(
+            "./ros/riberry_startup/systemd", systemd_target_dir, dry_run=dry_run
+        )
+        added_user_symlinks += create_symlinks(
+            "./ros/riberry_startup/systemd/user", systemd_target_dir, username=username,
+            dry_run=dry_run
+        )
     added_symlinks += create_symlinks(
         systemd_source_dir, systemd_target_dir, dry_run=dry_run
     )

--- a/install.py
+++ b/install.py
@@ -118,7 +118,6 @@ def main(dry_run=False, enable_oneshot=False):
     bin_target_dir = "/usr/local/bin"
     systemd_target_dir = "/etc/systemd/system"
 
-    copy_files("./boot", "/boot", dry_run=dry_run)
     create_symlinks(bin_source_dir, bin_target_dir, dry_run=dry_run)
 
     if dry_run is False:
@@ -146,6 +145,7 @@ def main(dry_run=False, enable_oneshot=False):
         )
 
     if identify_device() == "Radxa Zero":
+        copy_files("./boot", "/boot", dry_run=dry_run)
         create_symlinks('./bin/radxa-zero', bin_target_dir, dry_run=dry_run)
         execute_dtc_command(
             dry_run,

--- a/riberry/battery/common.py
+++ b/riberry/battery/common.py
@@ -16,6 +16,8 @@ def decide_battery_i2c_bus_number():
         bus_number = 1
     elif device_type == "Radxa Zero":
         bus_number = 3
+    elif device_type == "Radxa ZERO 3":
+        bus_number = 3
     else:
         bus_number = None
     return bus_number

--- a/riberry/com/i2c_base.py
+++ b/riberry/com/i2c_base.py
@@ -58,6 +58,8 @@ class I2CBase(ComBase):
             self.i2c = I2C(self.i2c_addr, bus=1)
         elif self.device_type == "Radxa Zero":
             self.i2c = I2C(self.i2c_addr, bus=1)
+        elif self.device_type == "Radxa ZERO 3":
+            self.i2c = I2C(self.i2c_addr, bus=3)
         elif self.device_type == "Khadas VIM4":
             self.i2c = I2C(self.i2c_addr, bus=5)
         elif self.device_type == "NVIDIA Jetson Xavier NX Developer Kit":

--- a/ros/riberry_startup/systemd/roscore.service
+++ b/ros/riberry_startup/systemd/roscore.service
@@ -11,7 +11,7 @@ SyslogIdentifier=%n
 Restart=always
 RestartSec=10s
 Type=simple
-User=rock
+User=root
 StandardOutput=journal
 StandardError=journal
 

--- a/ros/riberry_startup/systemd/user/riberry_startup.service
+++ b/ros/riberry_startup/systemd/user/riberry_startup.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run user-specific ROS nodes
+Description=Startup Riberry launch service
 # This service starts after roscore.service
 After=roscore.service
 # This service requires roscore.service
@@ -10,12 +10,12 @@ BindsTo=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roslaunch riberry_startup user.launch --wait'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roslaunch riberry_startup riberry_startup.launch --wait'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s
 Type=simple
-User=rock
+User=%I
 
 [Install]
 WantedBy=multi-user.target

--- a/ros/riberry_startup/systemd/user/user.service
+++ b/ros/riberry_startup/systemd/user/user.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Startup Riberry launch service
+Description=Run user-specific ROS nodes
 # This service starts after roscore.service
 After=roscore.service
 # This service requires roscore.service
@@ -10,12 +10,12 @@ BindsTo=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roslaunch riberry_startup riberry_startup.launch --wait'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roslaunch riberry_startup user.launch --wait'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s
 Type=simple
-User=rock
+User=%I
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/user/display_information.service
+++ b/systemd/user/display_information.service
@@ -10,7 +10,7 @@ ExecStart=/usr/local/bin/run_display_information.sh
 Restart=always
 RestartSec=10
 SyslogIdentifier=%n
-User=rock
+User=%I
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds support for the Radxa Zero 3.

Additionally, since the username is not necessarily limited to "rock," systemctl has been modified to accept usernames dynamically. This affects `display_information.service`, `riberry_startup.service`, and `user.service`.

When running `sudo ./install.py` as the "rock" user, you will need to access the services with the `@rock` suffix, like this:

```
sudo systemctl status display_information@rock.service
sudo journalctl -fu  display_information@rock.service
```
