### PR TITLE
Update low resulotion for D405

### DIFF
--- a/ros/riberry_startup/launch/d405.launch
+++ b/ros/riberry_startup/launch/d405.launch
@@ -18,10 +18,10 @@
     <arg name="depth_width" value="1280" if="$(arg high_resolution)" />
     <arg name="depth_height" value="720" if="$(arg high_resolution)" />
     <!-- Low resolution -->
-    <arg name="color_width" value="848" unless="$(arg high_resolution)" />
-    <arg name="color_height" value="480" unless="$(arg high_resolution)" />
-    <arg name="depth_width" value="424" unless="$(arg high_resolution)" />
-    <arg name="depth_height" value="240" unless="$(arg high_resolution)" />
+    <arg name="color_width" value="424" unless="$(arg high_resolution)" />
+    <arg name="color_height" value="240" unless="$(arg high_resolution)" />
+    <arg name="depth_width" value="480" unless="$(arg high_resolution)" />
+    <arg name="depth_height" value="270" unless="$(arg high_resolution)" />
   </include>
 
 </launch>

--- a/ros/riberry_startup/launch/d405.launch
+++ b/ros/riberry_startup/launch/d405.launch
@@ -4,6 +4,7 @@
   <arg name="enable_depth" default="true" />
   <arg name="color_fps" default="15" />
   <arg name="depth_fps" default="15" />
+  <arg name="exposure" default="10000" />
 
   <!-- D405 -->
   <include file="$(find realsense2_camera)/launch/rs_camera.launch">
@@ -23,5 +24,9 @@
     <arg name="depth_width" value="480" unless="$(arg high_resolution)" />
     <arg name="depth_height" value="270" unless="$(arg high_resolution)" />
   </include>
+
+  <rosparam subst_value="true">
+    /camera/stereo_module/exposure: $(arg exposure)
+  </rosparam>
 
 </launch>


### PR DESCRIPTION
In this pull request, we investigated low-resolution image sizes compatible with both USB2 and USB3:
Color: 424x240
Depth: 480x270

References:
Results from rs-enumerate-devices when using D405 with USB2:
https://gist.github.com/708yamaguchi/17282e2467d1205291c6aef1cd7c0e6a

Results from rs-enumerate-devices when using D405 with USB3:
https://gist.github.com/708yamaguchi/8d9e1f88bf711c965eda7b87cfa7e306