### PR TITLE
Change ROS_MASTER_URI and ROS_NAMESPACE based on riberry.user

### DIFF
--- a/etc/opt/riberry/riberry.user
+++ b/etc/opt/riberry/riberry.user
@@ -1,1 +1,7 @@
 SETUP=/home/rock/ros/kxr/devel/setup.bash
+
+# Comment in when you use external computer's roscore
+# RIBERRY_ROS_MASTER_IP=
+
+# Comment in when you change ROS namespace
+# ROS_NAMESPACE=

--- a/ros/riberry_startup/node_scripts/change_systemd_rosmaster.py
+++ b/ros/riberry_startup/node_scripts/change_systemd_rosmaster.py
@@ -104,7 +104,11 @@ if __name__ == "__main__":
         rospy.loginfo("[change_systemd_rosmaster] rospy node finished")
 
     with Manager() as manager:
-        next_ros_master_ip = manager.Value('s', 'localhost')
+        try:
+            ip = os.environ['ROS_MASTER_URI'][7:-6]  # http://192.X.Y.1:11311 -> 192.X.Y.1
+            next_ros_master_ip = manager.Value('s', ip)
+        except KeyError:
+            next_ros_master_ip = manager.Value('s', 'localhost')
         while True:
             # Use rospy inside process to completely reset rospy.init_node()
             # after process finished

--- a/ros/riberry_startup/systemd/change_systemd_rosmaster.service
+++ b/ros/riberry_startup/systemd/change_systemd_rosmaster.service
@@ -7,7 +7,7 @@ BindsTo=roscore.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && rosrun riberry_startup change_systemd_rosmaster.py'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && rosrun riberry_startup change_systemd_rosmaster.py'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s

--- a/ros/riberry_startup/systemd/roscore.service
+++ b/ros/riberry_startup/systemd/roscore.service
@@ -6,7 +6,7 @@ Requires=NetworkManager.service
 [Service]
 EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="ROSCONSOLE_FORMAT='[${severity}] [${time}] [${node}:${logger}]: ${message}'"
-ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py --rossetmaster $RIBERRY_ROS_MASTER_IP) && roscore'
+ExecStart=/bin/bash -c '. $SETUP && export $(python3 $(rospack find riberry_startup)/scripts/get_roshost.py) && roscore'
 SyslogIdentifier=%n
 Restart=always
 RestartSec=10s

--- a/systemd/user/display_information.service
+++ b/systemd/user/display_information.service
@@ -4,6 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+EnvironmentFile=-/etc/opt/riberry/riberry.user
 Environment="LOG_LEVEL=DEBUG"
 Type=simple
 ExecStart=/usr/local/bin/run_display_information.sh


### PR DESCRIPTION
When using leader/follower control, it is important to assign separate `ROS_MASTER_URI` and `ROS_NAMESPACE` values for each robot.