### PR TITLE
Each mode get base namespace for KXRROSRobotInterface

### DIFF
--- a/riberry/mode.py
+++ b/riberry/mode.py
@@ -25,3 +25,9 @@ class Mode:
 
     def mode_cb(self, msg):
         self.mode = msg.data
+
+    def get_base_namespace(self):
+        """Return the clean namespace for the node."""
+        full_namespace = rospy.get_namespace()
+        last_slash_pos = full_namespace.rfind("/")
+        return full_namespace[:last_slash_pos] if last_slash_pos != 0 else ""

--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -39,7 +39,7 @@ class MotionManager:
             raise Exception(f"skrobot version is not greater than {required_version}. (current version: {current_version})\npip install scikit-robot -U")
         # Create robot model to control pressure
         robot_model = RobotModel()
-        namespace = ""
+        namespace = self.get_base_namespace()
         with no_mesh_load_mode():
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
@@ -347,3 +347,9 @@ class MotionManager:
         message = "IK success"
         rospy.loginfo(message)
         return (moved_motion, message)
+
+    def get_base_namespace(self):
+        """Return the clean namespace for the node."""
+        full_namespace = rospy.get_namespace()
+        last_slash_pos = full_namespace.rfind("/")
+        return full_namespace[:last_slash_pos] if last_slash_pos != 0 else ""

--- a/ros/riberry_startup/node_scripts/data_collection_mode.py
+++ b/ros/riberry_startup/node_scripts/data_collection_mode.py
@@ -122,7 +122,7 @@ class DataCollectionMode(Mode):
         # Create robot model
         self.additional_msg = "Creating robot model..."
         robot_model = RobotModel()
-        namespace = ""
+        namespace = self.get_base_namespace()
         with no_mesh_load_mode():
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")

--- a/ros/riberry_startup/node_scripts/keyword_to_action.py
+++ b/ros/riberry_startup/node_scripts/keyword_to_action.py
@@ -22,7 +22,7 @@ class KeywordToAction:
     def __init__(self):
         # Create robot model to control pressure
         robot_model = RobotModel()
-        namespace = ""
+        namespace = self.get_base_namespace()
         with no_mesh_load_mode():
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
@@ -207,6 +207,12 @@ class KeywordToAction:
             info = f"Unknown keyword: {keyword}"
             self.info_on_atoms3(info)
             rospy.logwarn(info)
+
+    def get_base_namespace(self):
+        """Return the clean namespace for the node."""
+        full_namespace = rospy.get_namespace()
+        last_slash_pos = full_namespace.rfind("/")
+        return full_namespace[:last_slash_pos] if last_slash_pos != 0 else ""
 
 
 if __name__ == "__main__":

--- a/ros/riberry_startup/node_scripts/pressure_control_mode.py
+++ b/ros/riberry_startup/node_scripts/pressure_control_mode.py
@@ -22,7 +22,7 @@ class PressureControlMode(Mode):
 
         # Create robot model to control pressure
         robot_model = RobotModel()
-        namespace = ""
+        namespace = self.get_base_namespace()
         with no_mesh_load_mode():
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")

--- a/ros/riberry_startup/node_scripts/servo_control_mode.py
+++ b/ros/riberry_startup/node_scripts/servo_control_mode.py
@@ -20,7 +20,7 @@ class ServoControlMode(Mode):
 
         # Create robot model to control servo
         robot_model = RobotModel()
-        namespace = ""
+        namespace = self.get_base_namespace()
         with no_mesh_load_mode():
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")


### PR DESCRIPTION
When creating `KXRROSRobotInterface`, some nodes does not catch the node namespace.

```
Apr 19 00:03:45 flesh-brevity user@rock.service[5024]: '[WARN] [1744988606.023624] [/leader/pressure_control_mode:rosout]: Waiting /robot_description_viz set.'
```

This PR adds `get_base_namespace()` function to solve this problem.
The implementation is copied from 
https://github.com/iory/rcb4/blob/96e3a2a04f85df7b5e9d8e23130b73d0c3760a2e/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py#L493-L497