### PR TITLE
Remove duplicated namespace

### DIFF
--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -45,7 +45,7 @@ class MotionManager:
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
         self.ri = TeachingRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
+            robot_model, namespace=namespace[1:], controller_timeout=60.0
         )
         self.joint_names = self.ri.robot.joint_names
         self.end_coords_name = rospy.get_param("~end_coords_name", None)

--- a/ros/riberry_startup/node_scripts/button_action_manager.py
+++ b/ros/riberry_startup/node_scripts/button_action_manager.py
@@ -113,7 +113,7 @@ class ButtonActionManager(threading.Thread):
         namespace = get_base_namespace()
         robot_model.load_urdf_from_robot_description(namespace + "/robot_description_viz")
         self.ri = KXRROSRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
+            robot_model, namespace=namespace[1:], controller_timeout=60.0
         )
 
 

--- a/ros/riberry_startup/node_scripts/data_collection_mode.py
+++ b/ros/riberry_startup/node_scripts/data_collection_mode.py
@@ -128,7 +128,7 @@ class DataCollectionMode(Mode):
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
         self.ri = KXRROSRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
+            robot_model, namespace=namespace[1:], controller_timeout=60.0
         )
         if self.ri is None:
             self.additional_msg = "Failed to Create robot model"

--- a/ros/riberry_startup/node_scripts/keyword_to_action.py
+++ b/ros/riberry_startup/node_scripts/keyword_to_action.py
@@ -28,7 +28,7 @@ class KeywordToAction:
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
         self.ri = KXRROSRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
+            robot_model, namespace=namespace[1:], controller_timeout=60.0
         )
 
         # Keyword extraction

--- a/ros/riberry_startup/node_scripts/pressure_control_mode.py
+++ b/ros/riberry_startup/node_scripts/pressure_control_mode.py
@@ -28,7 +28,7 @@ class PressureControlMode(Mode):
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
         self.ri = KXRROSRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
+            robot_model, namespace=namespace[1:], controller_timeout=60.0
         )
 
         # Button and mode callback

--- a/ros/riberry_startup/node_scripts/servo_control_mode.py
+++ b/ros/riberry_startup/node_scripts/servo_control_mode.py
@@ -26,7 +26,7 @@ class ServoControlMode(Mode):
             robot_model.load_urdf_from_robot_description(
                 namespace + "/robot_description_viz")
         self.ri = KXRROSRobotInterface(
-            robot_model, namespace=namespace, controller_timeout=60.0
+            robot_model, namespace=namespace[1:], controller_timeout=60.0
         )
 
         # Button and mode callback


### PR DESCRIPTION
Judging from how namespaces are handled in KXRROSRobotInterface, it seems that slashes might be duplicated.
https://github.com/iory/rcb4/blob/b40a0d72d7bb9fe149de066a5a9361f9114f5540/ros/kxr_controller/python/kxr_controller/kxr_interface.py#L27