### PR TITLE
Check if robots have battery reader

### DIFF
--- a/bin/display_information.py
+++ b/bin/display_information.py
@@ -481,15 +481,16 @@ class DisplayInformation:
 
 if __name__ == "__main__":
     battery_bus_number = decide_battery_i2c_bus_number()
-    if MP2760BatteryMonitor.exists(battery_bus_number):
-        print("[Display Information] Use JSK Battery Board")
-        battery_readers.append(MP2760BatteryMonitor(battery_bus_number))
-    if PisugarBatteryReader.exists(battery_bus_number):
-        print("[Display Information] Use Pisugar")
-        battery_readers.append(PisugarBatteryReader(battery_bus_number))
-    for battery_reader in battery_readers:
-        battery_reader.daemon = True
-        battery_reader.start()
+    if battery_bus_number is not None:
+        if MP2760BatteryMonitor.exists(battery_bus_number):
+            print("[Display Information] Use JSK Battery Board")
+            battery_readers.append(MP2760BatteryMonitor(battery_bus_number))
+        if PisugarBatteryReader.exists(battery_bus_number):
+            print("[Display Information] Use Pisugar")
+            battery_readers.append(PisugarBatteryReader(battery_bus_number))
+        for battery_reader in battery_readers:
+            battery_reader.daemon = True
+            battery_reader.start()
 
     display_thread = threading.Thread(target=DisplayInformation().run_with_catch)
     display_thread.daemon = True


### PR DESCRIPTION
In Module LLM, `decide_battery_i2c_bus_number()` returns None

```
rock@pervasive-sorcerer:~/ros/kxr/src/riberry/bin$ python3 display_information.py                    
Traceback (most recent call last):                                                                   
  File "/home/rock/ros/kxr/src/riberry/bin/display_information.py", line 484, in <module>            
    if MP2760BatteryMonitor.exists(battery_bus_number):                                              
  File "/home/rock/ros/kxr/src/riberry/riberry/battery/mp2760.py", line 139, in exists               
    bus.read_byte(device_address)                                                                    
  File "/usr/local/lib/python3.10/dist-packages/smbus2/smbus2.py", line 394, in read_byte            
    self._set_address(i2c_addr, force=force)                                                         
  File "/usr/local/lib/python3.10/dist-packages/smbus2/smbus2.py", line 356, in _set_address         
    ioctl(self.fd, I2C_SLAVE, address)                                                               
TypeError: argument must be an int, or have a fileno() method.  
```