### PR TITLE
Add chatbot node using Azure OpenAI

### DIFF
--- a/riberry/chatbot.py
+++ b/riberry/chatbot.py
@@ -1,0 +1,36 @@
+from openai import AzureOpenAI
+
+from riberry.credentials import load_azure_credentials
+
+
+class Chatbot:
+    def __init__(self, system_prompt="You are a helpful assistant.", model="gpt-4.1-nano"):
+        api_key, endpoint = load_azure_credentials("/etc/opt/riberry/credentials.json")
+        self.client = AzureOpenAI(
+            api_version="2024-12-01-preview",
+            azure_endpoint=endpoint,
+            api_key=api_key,
+        )
+        self.set_system_prompt(system_prompt)
+        self.model = model
+
+    def set_system_prompt(self, system_prompt):
+        self.system_prompt = system_prompt
+
+    def generate_response(self, user_prompt):
+        try:
+            response = self.client.chat.completions.create(
+                messages=[
+                    {"role": "system", "content": self.system_prompt},
+                    {"role": "user", "content": user_prompt}
+                ],
+                max_completion_tokens=800,
+                temperature=1.0,
+                top_p=1.0,
+                frequency_penalty=0.0,
+                presence_penalty=0.0,
+                model=self.model
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            return f"Error: {e}"

--- a/riberry/credentials.py
+++ b/riberry/credentials.py
@@ -1,0 +1,31 @@
+import json
+import os
+
+
+def load_azure_credentials(filepath):
+    """Load credentials and export them as environment variable"""
+    if not os.path.exists(filepath):
+        return
+    print(f"Load credentials from {filepath}")
+    try:
+        with open(filepath) as f:
+            config = json.load(f)
+        api_key = config.get('AZURE_API_KEY')
+        endpoint = config.get('AZURE_ENDPOINT')
+        if api_key:
+            os.environ['AZURE_API_KEY'] = api_key
+        if endpoint:
+            os.environ['AZURE_ENDPOINT'] = endpoint
+    except Exception as e:
+        print(f"Error reading config file: {e}")
+        return None
+    # Check environment variables even without credential json
+    try:
+        api_key = os.environ['AZURE_API_KEY']
+        endpoint = os.environ['AZURE_ENDPOINT']
+    except KeyError as e:
+        print(f"[WARNING] Environment variable '{e}' is not set.")
+        print("Azure API cannot be used.\n")
+        api_key = ""
+        endpoint = ""
+    return (api_key, endpoint)

--- a/riberry/embedding_cache.py
+++ b/riberry/embedding_cache.py
@@ -5,6 +5,7 @@ import numpy as np
 from openai import AzureOpenAI
 from sklearn.metrics.pairwise import cosine_similarity
 
+from riberry.credentials import load_azure_credentials
 from riberry.filecheck_utils import get_cache_dir
 
 
@@ -32,36 +33,11 @@ class EmbeddingCache:
             for key in list(self.cache.keys()):
                 print(f"- {key}")
             print("")
-        self._load_credentials("/etc/opt/riberry/credentials.json")
-        try:
-            api_key = os.environ['AZURE_API_KEY']
-            endpoint = os.environ['AZURE_ENDPOINT']
-        except KeyError as e:
-            print(f"[WARNING] Environment variable '{e}' is not set.")
-            print("Azure API cannot be used.\n")
-            api_key = ""
-            endpoint = ""
+        api_key, endpoint = load_azure_credentials("/etc/opt/riberry/credentials.json")
         self.client = AzureOpenAI(
             api_key=api_key,
             azure_endpoint=endpoint,
             api_version="2024-10-01-preview",)
-
-    def _load_credentials(self, filepath):
-        """Load credentials and export them as environment variable"""
-        if not os.path.exists(filepath):
-            return
-        print(f"Load credentials from {filepath}")
-        try:
-            with open(filepath) as f:
-                config = json.load(f)
-            api_key = config.get('AZURE_API_KEY')
-            endpoint = config.get('AZURE_ENDPOINT')
-            if api_key:
-                os.environ['AZURE_API_KEY'] = api_key
-            if endpoint:
-                os.environ['AZURE_ENDPOINT'] = endpoint
-        except Exception as e:
-            print(f"Error reading config file: {e}")
 
     def _load_cache(self):
         """

--- a/ros/riberry_startup/launch/module_llm_chatbot.launch
+++ b/ros/riberry_startup/launch/module_llm_chatbot.launch
@@ -1,0 +1,16 @@
+<launch>
+
+  <arg name="system_prompt" />
+
+  <include file="$(find riberry_startup)/launch/module_llm_speech_to_text.launch" />
+
+  <node name="chatbot_node"
+	pkg="riberry_startup" type="chatbot_node.py"
+	respawn="true" output="screen">
+    <rosparam subst_value="true">
+      system_prompt: $(arg system_prompt)
+    </rosparam>
+    <remap from="~input" to="speech_to_text" />
+  </node>
+
+</launch>

--- a/ros/riberry_startup/node_scripts/chatbot_node.py
+++ b/ros/riberry_startup/node_scripts/chatbot_node.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import rospy
+from speech_recognition_msgs.msg import SpeechRecognitionCandidates
+from std_msgs.msg import String
+
+from riberry.chatbot import Chatbot
+
+
+class ChatbotNode:
+    def __init__(self):
+        system_prompt = rospy.get_param(
+            '~system_prompt', 'You are a helpful assistant.')
+        model = "gpt-4.1-nano"
+        self.chatbot = Chatbot(system_prompt, model)
+        rospy.loginfo(f"ChatbotNode - model: {model}")
+        rospy.loginfo(f"System prompt: {system_prompt}")
+        rospy.Subscriber('~input', SpeechRecognitionCandidates, self.cb)
+        self.pub = rospy.Publisher('~output', String, queue_size=1)
+
+    def cb(self, msg):
+        user_prompt = msg.transcript[0]
+        rospy.loginfo(f"Received user prompt: {user_prompt}")
+        system_output = self.chatbot.generate_response(user_prompt)
+        rospy.loginfo(f"Generated response: {system_output}")
+        self.pub.publish(system_output)
+
+if __name__ == '__main__':
+    rospy.init_node('chatbot_node')
+    node = ChatbotNode()
+    rospy.spin()

--- a/ros/riberry_startup/sample/sample_chatbot.py
+++ b/ros/riberry_startup/sample/sample_chatbot.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from riberry.chatbot import Chatbot
+
+
+def main():
+    system_prompt = "あなたはユーザーの入力から操作対象物体の名前を英語で抽出して返すアシスタントです。物体名だけを英語で答えてください。"
+    model = "gpt-4.1-nano"
+    chatbot = Chatbot(system_prompt=system_prompt, model=model)
+
+    print(f"Chatbot CLI ({model}) - Type 'exit' to quit\n")
+    print(f"System prompt: {system_prompt}")
+    while True:
+        # Example: "今からコーヒーポットの使い方を教えます。"
+        user_prompt = input("You: ")
+        if user_prompt.lower() in ['exit', 'quit']:
+            print("Goodbye!")
+            break
+
+        system_output = chatbot.generate_response(user_prompt)
+        print(f"Bot: {system_output}\n")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I add
- `Chatbot` class
- chatbot CLI sample
- chatbot node
- chatbot launch for Module LLM

By using the `SpeechToText` mode of Module LLM, you can relay topics from /speech_to_text_raw to /speech_to_text only when the button is pressed and activated.
This combination enables easy ON/OFF switching for the chatbot, eliminating unnecessary token usage.