### PR TITLE
Add github.io link for flashing firmware from web browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can use the dry-run option to see which scripts will be installed without ac
 
 Please write the programs found under the [firmware](https://github.com/iory/riberry/tree/main/firmware) section into the atom s3 and atom echo to display the IP and capture audio.
 
+You can also flash firmware directly from your web browser via USB connection at: https://iory.github.io/riberry/
+
 
 ### Atom S3 Display
 

--- a/firmware/atom_s3_i2c_display/README.md
+++ b/firmware/atom_s3_i2c_display/README.md
@@ -25,6 +25,10 @@ pip3 install platformio -U
 
 ### Compile and write firmware to atom s3
 
+You can flash firmware directly from your web browser via USB connection at: https://iory.github.io/riberry/
+
+Alternatively, you can compile and upload using PlatformIO:
+
 ```
 pio run -t upload
 ```


### PR DESCRIPTION
We can flash firmware directly from web browser via USB connection at: https://iory.github.io/riberry/

<img width="384" alt="Screenshot 2025-06-25 at 15 37 24" src="https://github.com/user-attachments/assets/547af71c-63c8-48df-9640-d03de7a4c15a" />
