### PR TITLE
Add firmware and ROS node to control Dynamixel via ESP-NOW

### DIFF
--- a/firmware/atomic_robot_tools/README.md
+++ b/firmware/atomic_robot_tools/README.md
@@ -11,3 +11,31 @@ pio run -t upload -e dynamixel_setBaudandID
 ```
 pio run -t upload -e dynamixel_safe_test
 ```
+
+## Control Dynamixel motor via ESPNOW communicaation
+
+1. Burn firmware to pairing devices
+
+    ```
+    # For main (sender) device. This device is usually connected to ROS computer.
+    pio run -t upload -e espnow_dynamixel_controller_main
+
+    # For receiver (secondary) device. This device is usually connected to atomic tools.
+    pio run -t upload -e espnow_dynamixel_controller_secondary
+    ```
+
+2. Start the pairing program on the computer connected to the main (sender) device
+
+    To protect the motor, Stop command is automatically sent 5 seconds after sending a Forward/Reverse command.
+
+    ```
+    rosrun riberry_startup espnow_dynamixel_controller_node.py
+    ```
+
+3. Send control command via rostopic
+
+    ```
+    rostopic pub /motor_command  std_msgs/String "data: 'Forward'"
+    rostopic pub /motor_command  std_msgs/String "data: 'Stop'"
+    rostopic pub /motor_command  std_msgs/String "data: 'Reverse'"
+    ```

--- a/firmware/atomic_robot_tools/platformio.ini
+++ b/firmware/atomic_robot_tools/platformio.ini
@@ -87,3 +87,46 @@ lib_deps =
     fastled/FastLED
     ROBOTIS-GIT/Dynamixel2Arduino
 build_src_filter = +<dynamixel_safe_test.cpp>
+
+[env:espnow_dynamixel_controller_main]
+platform = espressif32
+board = m5stack-atoms3
+framework = arduino
+monitor_speed = 115200
+check_tool = cppcheck
+check_flags =
+  cppcheck: --enable=all --inconclusive --force --error-exitcode=1
+check_src_filters =
+  +<./src>
+  +<./lib>
+lib_deps =
+    m5stack/M5Unified@^0.1.12
+    m5stack/M5AtomS3
+    fastled/FastLED@3.9.9
+    ROBOTIS-GIT/Dynamixel2Arduino
+    lovyan03/LovyanGFX@^1.1.9
+    powerbroker2/SerialTransfer
+lib_extra_dirs = ../esp_now_pairing/lib/
+build_src_filter = +<espnow_dynamixel_controller.cpp>
+build_flags = -DENV_MAIN
+
+[env:espnow_dynamixel_controller_secondary]
+platform = espressif32
+board = m5stack-atoms3
+framework = arduino
+monitor_speed = 115200
+check_tool = cppcheck
+check_flags =
+  cppcheck: --enable=all --inconclusive --force --error-exitcode=1
+check_src_filters =
+  +<./src>
+  +<./lib>
+lib_deps =
+    m5stack/M5Unified@^0.1.12
+    m5stack/M5AtomS3
+    fastled/FastLED@3.9.9
+    ROBOTIS-GIT/Dynamixel2Arduino
+    lovyan03/LovyanGFX@^1.1.9
+    powerbroker2/SerialTransfer
+lib_extra_dirs = ../esp_now_pairing/lib/
+build_src_filter = +<espnow_dynamixel_controller.cpp>

--- a/firmware/atomic_robot_tools/src/espnow_dynamixel_controller.cpp
+++ b/firmware/atomic_robot_tools/src/espnow_dynamixel_controller.cpp
@@ -1,0 +1,192 @@
+// Mainly copied from dynamixe_current.cpp
+#include <Dynamixel2Arduino.h>
+#define DXL_SERIAL Serial1
+#define SERIAL_CONFIG SERIAL_8N1
+const long BAUDRATE = 2000000;  // 2Mが限界だった
+const int TIMEOUT = 100;        // ms
+const uint8_t DXL_ID = 0;
+const float DXL_PROTOCOL_VERSION = 2.0;
+
+const int EN_PIN = 6;  // Enable Pin
+const int RX_PIN = 5;
+const int TX_PIN = 38;
+
+Dynamixel2Arduino dxl(DXL_SERIAL, EN_PIN);
+
+void setupDXL() {
+    DXL_SERIAL.begin(BAUDRATE, SERIAL_CONFIG, RX_PIN, TX_PIN, false, TIMEOUT);
+    dxl.begin(BAUDRATE);
+    dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
+
+    dxl.torqueOff(DXL_ID);
+    dxl.setOperatingMode(DXL_ID, OP_CURRENT);
+    dxl.torqueOn(DXL_ID);
+
+    dxl.writeControlTableItem(ControlTableItem::PROFILE_VELOCITY, DXL_ID, 0);
+}
+
+// 電圧を読み取る関数
+float readVoltage() {
+    int32_t voltage_raw = dxl.readControlTableItem(ControlTableItem::PRESENT_INPUT_VOLTAGE, DXL_ID);
+    return (float)voltage_raw / 10.0;  // Unit [V]
+}
+
+// 温度を読み取る関数
+float readTemperature() {
+    int32_t temperature = dxl.readControlTableItem(ControlTableItem::PRESENT_TEMPERATURE, DXL_ID);
+    return (float)temperature;  // Unit [C]
+}
+
+// Mainly copied from esp_now_pairing
+#define LGFX_M5ATOMS3
+#define LGFX_USE_V1
+#include <SerialTransfer.h>
+
+#include <LGFX_AUTODETECT.hpp>
+#include <LovyanGFX.hpp>
+
+#include "pairing.h"
+
+#ifdef ENV_MAIN
+String main_or_secondary = "Main";
+#else
+String main_or_secondary = "Secondary";
+#endif
+
+static LGFX lcd;
+const int channel = 1;  // To avoid interference, channels should be at least 3 apart.
+Pairing pairing(channel);
+String previousMessage = "";
+SerialTransfer transfer;
+uint8_t buffer[256];
+
+// 表示更新用の変数
+unsigned long lastDisplayTime = 0;
+const unsigned long displayInterval = 500;  // 表示更新間隔 [ms]
+String currentStatusMessage = "";           // 現在の状態メッセージを保持する変数
+
+template <typename T>
+void write(const T &data, const size_t len) {
+    transfer.txObj(data, 0, len);
+    transfer.sendData(len);
+}
+
+String getBaseDisplayMessage() {
+    return main_or_secondary + " ch." + String(channel) + "\nMy MAC:\n" + pairing.getMyMACAddress();
+}
+
+void printToLCD(const String &message) {
+    if (message == previousMessage) {
+        return;
+    }
+    previousMessage = message;
+    lcd.fillScreen(lcd.color565(0, 0, 0));
+    lcd.setCursor(0, 0);
+    lcd.println(message);
+}
+
+void initLCD() {
+    lcd.init();
+    lcd.setRotation(0);
+    lcd.clear();
+    lcd.setTextSize(1.2);
+}
+
+void setup() {
+    initLCD();
+    currentStatusMessage = "Initializing...";
+    printToLCD(currentStatusMessage);
+
+    int xCoreID = 1;
+    pairing.createTask(xCoreID);
+    String baseMessage = getBaseDisplayMessage();
+    currentStatusMessage = baseMessage;
+    printToLCD(currentStatusMessage);
+
+    USBSerial.begin(115200);
+    transfer.begin(USBSerial);
+    delay(1500);
+
+    if (main_or_secondary == "Main") {
+        currentStatusMessage =
+                baseMessage + "\n\nWait for command from espnow_dynamixel_controller.py";
+        printToLCD(currentStatusMessage);
+    } else if (main_or_secondary == "Secondary") {
+        setupDXL();
+        currentStatusMessage = baseMessage + "\n\nWait for command from Main";
+        printToLCD(currentStatusMessage);
+    }
+}
+
+void control_dynamixel(PairingData data) {
+    String baseMessage = getBaseDisplayMessage();
+    if (data.IPv4[0] == 0) {
+        dxl.setGoalCurrent(DXL_ID, 500, UNIT_MILLI_AMPERE);
+        currentStatusMessage = baseMessage + "\n\nForward rotation";
+    } else if (data.IPv4[0] == 127) {
+        dxl.setGoalCurrent(DXL_ID, 0, UNIT_MILLI_AMPERE);
+        currentStatusMessage = baseMessage + "\n\nStop rotation";
+    } else if (data.IPv4[0] == 255) {
+        dxl.setGoalCurrent(DXL_ID, -800, UNIT_MILLI_AMPERE);
+        currentStatusMessage = baseMessage + "\n\nReverse rotation";
+    } else {
+        currentStatusMessage = baseMessage + "\n\nUnknown command: " + String(data.IPv4[0]);
+    }
+}
+
+PairingData dataToSend = {{255, 255, 255, 255}};
+
+void loop() {
+    size_t available = transfer.available();
+    if (available > 0) {
+        transfer.rxObj(buffer, 0, available);
+        switch (buffer[0]) {
+            case 0x11:
+                write(main_or_secondary, main_or_secondary.length());
+                break;
+            case 0x12: {
+                std::map<String, PairingData> pairedDataMap = pairing.getPairedData();
+                if (!pairedDataMap.empty()) {
+                    auto it = pairedDataMap.begin();
+                    write(it->second.IPv4, 4);
+                }
+                break;
+            }
+            case 0x13:
+                for (int i = 0; i < 4; i++) {
+                    dataToSend.IPv4[i] = buffer[i + 1];
+                }
+                pairing.setDataToSend(dataToSend);
+                break;
+            default:
+                break;
+        }
+        currentStatusMessage = getBaseDisplayMessage() + "\n\nReceive command from computer";
+    }
+
+    std::map<String, PairingData> pairedDataMap = pairing.getPairedData();
+    for (const auto &pair : pairedDataMap) {
+        if (main_or_secondary == "Secondary") {
+            control_dynamixel(pair.second);
+        }
+    }
+
+    unsigned long currentTime = millis();
+    if (currentTime - lastDisplayTime >= displayInterval) {
+        // Mainデバイスの場合、現在のステータスメッセージのみ表示
+        if (main_or_secondary == "Main") {
+            printToLCD(currentStatusMessage);
+        }
+        // Secondaryデバイスの場合、現在のステータスメッセージとモーター情報を結合して表示
+        else {
+            String motorInfo;
+            motorInfo = String("\n\n") + String(readVoltage(), 2) + " [V]\n" +
+                        String((int)dxl.getPresentCurrent(DXL_ID, UNIT_MILLI_AMPERE)) + " [mA]\n" +
+                        String((int)readTemperature()) + " [C]";
+            printToLCD(currentStatusMessage + motorInfo);
+        }
+        lastDisplayTime = currentTime;
+    }
+
+    delay(10);
+}

--- a/ros/riberry_startup/node_scripts/espnow_dynamixel_controller_node.py
+++ b/ros/riberry_startup/node_scripts/espnow_dynamixel_controller_node.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+import threading
+
+import rospy
+from std_msgs.msg import String
+
+from riberry.com.uart_base import usb_devices
+from riberry.esp_now_pairing import ESPNowPairing
+from riberry.esp_now_pairing import find_USB_pairing_devices
+from riberry.esp_now_pairing import Role
+
+
+class EspNowControllerNode:
+    """
+    ROS node to control ESP-NOW devices.
+    """
+    def __init__(self):
+        rospy.init_node('esp_now_controller', anonymous=True)
+        # Publish one of the keys from COMMAND_MAP to the /motor_command topic.
+        rospy.Subscriber('motor_command', String, self.command_callback)
+
+        self.esp_now_pairing = None
+        self.stop_timer = None
+        self.lock = threading.Lock()
+
+        # Keep a list of ports from the previous scan.
+        self.prev_ports = []
+
+        self.COMMAND_MAP = {
+            "Forward": "0.0.0.0",
+            "Stop": "127.0.0.0",
+            "Reverse": "255.0.0.0"
+        }
+
+        self.discovery_thread = threading.Thread(target=self.manage_device_connection, daemon=True)
+        self.discovery_thread.start()
+
+    def manage_device_connection(self):
+        """
+        Manages device connection and disconnection.
+        """
+        rate = rospy.Rate(1)
+        while not rospy.is_shutdown():
+            try:
+                current_ports = usb_devices()
+            except Exception as e:
+                rospy.logerr(f"Error while scanning for USB devices: {e}")
+                current_ports = []
+
+            # --- Check if the connected device has been disconnected ---
+            with self.lock:
+                if self.esp_now_pairing is not None:
+                    connected_port = self.esp_now_pairing.com.serial.port_name
+                    if connected_port not in current_ports:
+                        rospy.logwarn(f"Detected disconnection of device {connected_port}. Waiting for reconnection.")
+                        self.esp_now_pairing = None
+
+            # --- Process only newly connected ports ---
+            # Search for new ports only if no device is connected.
+            if self.esp_now_pairing is None:
+                new_ports = [p for p in current_ports if p not in self.prev_ports]
+
+                if new_ports:
+                    rospy.loginfo(f"New USB ports detected: {new_ports}")
+                    pairing_devices = find_USB_pairing_devices(new_ports)
+
+                    main_device_info = None
+                    for dev in pairing_devices:
+                        if dev and dev["role"] == Role.Main:
+                            main_device_info = dev
+                            break
+
+                    if main_device_info:
+                        com_port = main_device_info["com"]
+                        rospy.loginfo(f"Controller device found: {com_port}. Attempting to connect.")
+                        with self.lock:
+                            try:
+                                # Confirm it's still None (for thread safety).
+                                if self.esp_now_pairing is None:
+                                    self.esp_now_pairing = ESPNowPairing(com=com_port, role=Role.Main)
+                                    rospy.loginfo(f"Successfully connected to device {com_port}.")
+                            except Exception as e:
+                                rospy.logerr(f"Failed to connect to device {com_port}: {e}")
+
+            # Finally, save the current list of ports.
+            self.prev_ports = current_ports
+            rate.sleep()
+
+    def send_command(self, command_ip):
+        """
+        Sends the actual command to the ESP-NOW device.
+        """
+        with self.lock:
+            if self.esp_now_pairing:
+                try:
+                    self.esp_now_pairing.set_pairing_info(command_ip)
+                    self.esp_now_pairing.pairing()
+                    rospy.loginfo(f"Command sent successfully: {command_ip}")
+                except Exception as e:
+                    rospy.logerr(f"Failed to send command: {e}. The device may have been disconnected.")
+                    self.esp_now_pairing = None
+                    rospy.logwarn("Connection with the device has been reset. Attempting to reconnect.")
+            else:
+                rospy.logwarn("Received a command, but no device is connected.")
+
+    def send_stop_command_auto(self):
+        rospy.loginfo("5 seconds have passed. Stopping the motor for safety.")
+        self.send_command(self.COMMAND_MAP["Stop"])
+
+    def command_callback(self, msg):
+        command = msg.data
+        rospy.loginfo(f"Command received: '{command}'")
+
+        if self.stop_timer and self.stop_timer.is_alive():
+            self.stop_timer.cancel()
+
+        if command in self.COMMAND_MAP:
+            command_ip = self.COMMAND_MAP[command]
+            self.send_command(command_ip)
+
+            if command in ["Forward", "Reverse"]:
+                self.stop_timer = threading.Timer(5.0, self.send_stop_command_auto)
+                self.stop_timer.start()
+        else:
+            rospy.logwarn(f"Undefined command: '{command}'")
+
+    def run(self):
+        rospy.loginfo("ESP-NOW controller node has started.")
+        rospy.spin()
+
+
+if __name__ == '__main__':
+    try:
+        node = EspNowControllerNode()
+        node.run()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
# Description

This pull request introduces a new feature that allows for the remote control of a Dynamixel servo motor from ROS over a wireless connection using ESP-NOW.

# Features

- Simple Setup
    Connect an `main` AtomS3 to the PC running ROS, and `secondary` AtomS3 to the target Dynamixel.
- Wireless Communication
    The two AtomS3 modules communicate with each other using ESP-NOW, a fast and low-latency protocol that does not require a Wi-Fi router.
- Automatic Pairing
    The AtomS3 devices pair automatically, eliminating the need for complex user configuration. (This feature depends on `esp_now_pairing` in riberry.)

# How to Use
1. Plug the `main` AtomS3 into your PC.
2. Launch the controller node by running the following command. This will allow you to send commands to the remote Dynamixel via ROS topics.
```
rosrun riberry_startup espnow_dynamixel_controller_node.py
```