### PR TITLE
Increase the motion save cycle frequency

### DIFF
--- a/riberry/motion_manager.py
+++ b/riberry/motion_manager.py
@@ -111,7 +111,7 @@ class MotionManager:
         # of the servo motor's potentiometer
         # This may cause the recorded motion to become temporally sparse.
         avs = []
-        for _ in range(5):
+        for _ in range(1):  # 5 -> 1 makes no motion difference.
             avs.append(self.ri.angle_vector())
         av_average = np.mean(avs, axis=0)
         for j, a in zip(self.joint_names, av_average):

--- a/riberry/teaching_manager.py
+++ b/riberry/teaching_manager.py
@@ -79,6 +79,7 @@ class TeachingManager:
         self.marker_manager.set_markers([])
         with open(record_filepath, mode='w') as f:
             rospy.loginfo(f'Start saving motion to {record_filepath}')
+            rate = rospy.Rate(10)
             while not rospy.is_shutdown():
                 # Finish recording
                 if self.motion_manager.is_stopped():
@@ -89,7 +90,7 @@ class TeachingManager:
                 # If self.add_motion() is already called
                 if self.start_time is not None:
                     self.marker_manager.add_marker(self.start_time)
-                rospy.sleep(0.1)
+                rate.sleep()
             json_data = {}
             json_data['motion'] = self.motion_manager.get_motion() +\
                 self.motion_manager.get_actions() +\


### PR DESCRIPTION
Previously, the motion save interval was 0.3 seconds, although it was intended to be 0.1 seconds.
This pull request fixes it to the intended 0.1 second interval.

Thank you for your cooperation, @nakane11 