### PR TITLE
feat: Add Push-to-Talk functionality to Speech-to-Text

### DIFF
--- a/ros/riberry_startup/launch/speech_to_text.launch
+++ b/ros/riberry_startup/launch/speech_to_text.launch
@@ -1,15 +1,16 @@
-<!-- Mainly copied from ros_speech_recognition/launch/speech_recognition.launch -->
-
 <launch>
-  <arg name="audio_topic" default="audio" />
-  <arg name="filtered_audio_topic" default="audio" />
+  <arg name="audio_topic" default="audio" doc="Final output topic from mux (input for VAD/STT)" />
   <arg name="audio_info_topic" default="audio_info" />
   <arg name="device" default="" />
 
-  <!-- audio capture from microphone -->
+  <arg name="raw_audio_topic" default="audio_raw" doc="Raw audio directly from microphone" />
+  <arg name="dummy_audio_topic" default="dummy_audio" doc="Topic for silence/dummy audio" />
+  <arg name="trigger_topic" default="/push_to_talk"
+       doc="Boolean topic to switch audio. True = Mic (Raw), False = Mute (Dummy)" />
+
   <node name="audio_capture" pkg="audio_capture" type="audio_capture"
         respawn="true">
-    <remap from="audio" to="$(arg audio_topic)" />
+    <remap from="audio" to="$(arg raw_audio_topic)" />
     <rosparam subst_value="true">
       format: wave
       channels: 1
@@ -20,13 +21,31 @@
     <param name="device" value="$(arg device)" />
   </node>
 
+  <node name="input_audio_mux" pkg="topic_tools" type="mux" respawn="true"
+        args="$(arg audio_topic) $(arg raw_audio_topic) $(arg dummy_audio_topic)">
+    <remap from="mux" to="input_audio_mux" />
+  </node>
+
+  <node name="input_audio_selector" pkg="riberry_startup" type="mux_selector.py" respawn="true" output="screen"
+        args="$(arg trigger_topic) 'm.data is True' $(arg raw_audio_topic)
+              $(arg trigger_topic) 'm.data is False' $(arg dummy_audio_topic)">
+    <remap from="mux" to="input_audio_mux" />
+    <param name="default_select" value="$(arg dummy_audio_topic)" />
+    <param name="wait" value="true" />
+  </node>
+
+  <node name="keyboard_push_to_talk" pkg="riberry_startup" type="key_trigger.py"
+        output="screen">
+    <remap from="trigger" to="$(arg trigger_topic)" />
+  </node>
+
   <node name="webrtcvad_ros"
         pkg="riberry_startup" type="webrtcvad_ros.py"
         output="screen" >
     <rosparam>
       aggressiveness: 1
     </rosparam>
-    <remap from="audio_data" to="$(arg filtered_audio_topic)" />
+    <remap from="audio_data" to="$(arg audio_topic)" />
     <remap from="audio_info" to="$(arg audio_info_topic)" />
   </node>
 
@@ -36,7 +55,5 @@
         output="screen">
     <remap from="audio" to="webrtcvad_ros/speech_audio"  />
     <remap from="audio_info" to="$(arg audio_info_topic)" />
-    <remap from="speech_to_text" to="speech_to_text"  />
   </node>
-
 </launch>

--- a/ros/riberry_startup/node_scripts/key_trigger.py
+++ b/ros/riberry_startup/node_scripts/key_trigger.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import select
+import sys
+import termios
+import time
+import tty
+
+import rospy
+from std_msgs.msg import Bool
+
+
+def get_key(settings, timeout=0.01):
+    """
+    Non-blocking key input.
+    """
+    tty.setraw(sys.stdin.fileno())
+    rlist, _, _ = select.select([sys.stdin], [], [], timeout)
+    if rlist:
+        key = sys.stdin.read(1)
+    else:
+        key = None
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+    return key
+
+
+def main():
+    rospy.init_node('key_trigger_node')
+
+    # Generic topic name 'trigger', intended to be remapped in launch file
+    pub = rospy.Publisher('trigger', Bool, queue_size=1)
+
+    settings = termios.tcgetattr(sys.stdin)
+
+    print("--------------------------------")
+    print("Key Trigger Node Running")
+    print(f"Topic: {pub.name}")
+    print("HOLD [SPACE] to publish True.")
+    print("RELEASE to publish False.")
+    print("--------------------------------")
+
+    last_msg = False
+    last_press_time = 0
+    last_pub_time = 0
+    # To prevent chattering
+    HOLD_TIMEOUT = 0.5
+
+    try:
+        while not rospy.is_shutdown():
+            # Check key input with short timeout (Reduced to 0.02 for better responsiveness)
+            key = get_key(settings, timeout=0.02)
+
+            current_time = time.time()
+            is_pressed = False
+
+            if key == ' ':
+                last_press_time = current_time
+                is_pressed = True
+            elif key == '\x03':  # Ctrl-C
+                break
+            else:
+                # Keep True if within timeout (anti-chattering)
+                if current_time - last_press_time < HOLD_TIMEOUT:
+                    is_pressed = True
+                else:
+                    is_pressed = False
+
+            # Logic to prevent flooding the subscriber
+            if is_pressed != last_msg:
+                # State changed: Log and Publish IMMEDIATELY
+                if is_pressed:
+                    rospy.loginfo(f"Trigger {pub.name}: Active (True)")
+                else:
+                    rospy.loginfo(f"Trigger {pub.name}: Inactive (False)")
+
+                pub.publish(is_pressed)
+                last_pub_time = current_time
+                last_msg = is_pressed
+            else:
+                # State unchanged: Publish at 10Hz (0.1s interval) as heartbeat
+                # This prevents lagging caused by queue flooding
+                if current_time - last_pub_time > 0.1:
+                    pub.publish(is_pressed)
+                    last_pub_time = current_time
+    except Exception as e:
+        print(e)
+    finally:
+        # Ensure False is published on exit
+        pub.publish(False)
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/ros/riberry_startup/node_scripts/mux_selector.py
+++ b/ros/riberry_startup/node_scripts/mux_selector.py
@@ -142,6 +142,8 @@ if __name__ == "__main__":
 
     # loop
     try:
+        if default_select is not None:
+            mux_client(default_select)
         before = default_select
         update_trigger(conditions, wait=wait)
         looprate = rospy.Rate(freq)


### PR DESCRIPTION
## Summary
This PR introduces a "Push-to-Talk" mechanism to the speech-to-text pipeline.
The system now defaults to a "Muted" state (using dummy audio) and only enables the microphone input when the user explicitly triggers it via keyboard.

## Changes

### 1. New Node: `key_trigger.py`
- Added a generic keyboard input node (`riberry_startup/scripts/key_trigger.py`).
- Publishes `True` to a specified topic while the Space key is held.

### 2. Fix: `mux_selector.py`
- **Forced Initialization**: Modified the script to explicitly call the mux service with the `default_select` topic upon startup.
- **Reason**: Previously, if the `default_select` param matched the internal initial state, the switch command was skipped. This fix ensures the system enters the correct state (e.g., Muted) immediately after launch.

### 3. Update: `speech_to_text.launch`
- **Audio Muxing**: Integrated `topic_tools/mux` to switch between `audio_raw` and `dummy_audio`.
- **Selector Logic**: Configured `mux_selector.py` to listen to the `/push_to_talk` topic.
- **Default State**: Set to `dummy_audio` (Muted) by default.
- **Trigger**: Integrated `key_trigger.py` mapped to `/push_to_talk`.

## Note on Key Trigger Behavior
To prevent chattering (signal interruption during continuous key press) caused by OS key repeat delays, the `key_trigger.py` node includes a **0.5-second hysteresis (hold timeout)**.
- **Behavior**: The microphone will remain active for approximately 0.5 seconds after you release the space bar.
- **Reason**: This delay is necessary to bridge the gap between key repeat signals on standard laptops, ensuring the audio stream is not cut off mid-sentence.

## Usage
1. Launch the file:
   ```bash
   roslaunch riberry_startup speech_to_text.launch