### PR TITLE
Add logging for recognized speech text

### DIFF
--- a/ros/riberry_startup/node_scripts/speech_to_text.py
+++ b/ros/riberry_startup/node_scripts/speech_to_text.py
@@ -54,6 +54,7 @@ class SpeechToText:
             rospy.loginfo(f"Waiting for result {len(data.get_raw_data())}")
             result = self.recognizer.recognize_google(
                 data, language=self.language)
+            rospy.loginfo(f"Recognized: {result}")
             msg = SpeechRecognitionCandidates(
                 transcript=[result],
                 confidence=[1.0],


### PR DESCRIPTION
## Summary
Modified `speech_to_text.py` to output the recognized text using `rospy.loginfo` immediately after successful recognition.

## Motivation / Context
Currently, when running `rostopic echo /speech_to_text`, Japanese characters are displayed as Unicode escape sequences, which makes them very difficult to read.

Previously, we had to use a complex command like the following just to check the recognized content properly:

```bash
rostopic echo --filter "print('transcript: [%s]\n---'%(', '.join(map(lambda x: '\'%s\''%(x), m.transcript))))" /speech_to_text
```

With this change, the recognized result is printed directly to the ROS log, making it instantly readable without needing complex CLI filters.