### PR TITLE
change shebang in webrtcvad_ros.py

### DIFF
--- a/ros/riberry_startup/node_scripts/webrtcvad_ros.py
+++ b/ros/riberry_startup/node_scripts/webrtcvad_ros.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Mainly copied from https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/master/webrtcvad_ros/node_scripts/webrtcvad_ros.py
 


### PR DESCRIPTION
I encountered the following error in webrtcvad_ros when I launched it on my laptop:
```
process[webrtcvad_ros-3]: started with pid [20640]
  File "/home/leus/kashiwagi_ws/src/riberry/ros/riberry_startup/node_scripts/webrtcvad_ros.py", line 75
    rospy.logwarn(f'speech duration: {speech_duration} dropped')
                                                              ^
SyntaxError: invalid syntax
```
After looking into it, I found that f-strings are only supported in Python 3.6 or later. 
To fix this, I modified the shebang line in webrtcvad_ros.py so that it explicitly uses Python 3.